### PR TITLE
fix(rbac): add events.k8s.io RBAC marker

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -21,14 +21,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - delete
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - create
@@ -38,6 +30,15 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - delete
+  - patch
 - apiGroups:
   - greenhouse.sap
   resources:

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -57,11 +57,12 @@ type garden struct {
 type careInstructionContextKey struct{}
 
 //+kubebuilder:rbac:groups=shoot-grafter.cloudoperators.dev,resources=careinstructions,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups=shoot-grafter.cloudoperators.dev,resources=careinstructions/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=shoot-grafter.cloudoperators.dev,resources=careinstructions/status,verbs=get;update;patch
 //+kubebuilder:rbac:groups=greenhouse.sap,resources=clusters,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch;delete
+//+kubebuilder:rbac:groups="",resources=events,verbs=create;patch;delete
+//+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=create;patch;delete
 
 func (r *CareInstructionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Setup the controller with the manager

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -62,7 +62,7 @@ type careInstructionContextKey struct{}
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups="",resources=events,verbs=create;patch;delete
-//+kubebuilder:rbac:groups="events.k8s.io",resources=events,verbs=create;patch;delete
+//+kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch;delete
 
 func (r *CareInstructionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Setup the controller with the manager


### PR DESCRIPTION
I added `events.k8s.io` RBAC marker and regenerated `role.yaml`.

This fix is done because there appeared logs like: `User \"system:serviceaccount:greenhouse:shoot-grafter\" cannot patch resource \"events\" in API group \"events.k8s.io\"`.