### PR TITLE
feat: trigger Shoot reconciliation from Greenhouse resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,17 @@ spec:
 
 *Note: Either `gardenClusterName` or `gardenClusterKubeConfigSecretName` must be provided (priority: kubeconfig secret > cluster name)
 
+### Triggering Reconciliation
+
+The annotation `shoot-grafter.cloudoperators.dev/reconcile: "true"` can be set on a **CareInstruction** or a **Greenhouse Cluster** to trigger reconciliation on demand.
+
+| Target | Effect |
+|--------|--------|
+| `CareInstruction` | Restarts the shoot controller for that CareInstruction, causing shoot-grafter to re-apply its config (OIDC, RBAC, labels) to all matching Shoots |
+| `Greenhouse Cluster` | Sets `gardener.cloud/operation: reconcile` on the matching Shoot in the Garden cluster, triggering Gardener's own reconciliation |
+
+The annotation is removed from the resource after processing.
+
 ### CareInstruction Status
 
 The CareInstruction status provides real-time information about the onboarding process:

--- a/api/v1alpha1/careinstruction_types.go
+++ b/api/v1alpha1/careinstruction_types.go
@@ -39,6 +39,9 @@ const (
 	// AuthConfigMapLabel is the label used to identify AuthenticationConfiguration ConfigMaps
 	AuthConfigMapLabel = "shoot-grafter.cloudoperators.dev/auth-configmap"
 
+	// ReconcileAnnotation is the annotation set on a Greenhouse Cluster to trigger reconciliation of the matching Shoot.
+	ReconcileAnnotation = "greenhouse.sap/reconcile"
+
 	// ShootStatusOnboarded indicates the shoot has been onboarded as a Greenhouse Cluster.
 	ShootStatusOnboarded = "Onboarded"
 

--- a/api/v1alpha1/careinstruction_types.go
+++ b/api/v1alpha1/careinstruction_types.go
@@ -135,6 +135,9 @@ type CareInstructionStatus struct {
 
 	// FailedClusters is the number of clusters that failed to be created by this CareInstruction.
 	FailedClusters int `json:"failedClusters,omitempty"`
+
+	// ShootControllerRestartCount is the number of times the shoot controller has been restarted.
+	ShootControllerRestartCount int `json:"shootControllerRestartCount,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/careinstruction_types.go
+++ b/api/v1alpha1/careinstruction_types.go
@@ -39,9 +39,8 @@ const (
 	// AuthConfigMapLabel is the label used to identify AuthenticationConfiguration ConfigMaps
 	AuthConfigMapLabel = "shoot-grafter.cloudoperators.dev/auth-configmap"
 
-	// ReconcileAnnotation can be set on a Greenhouse Cluster or CareInstruction to trigger reconciliation
-	// of the matching Shoot(s).
-	ReconcileAnnotation = "greenhouse.sap/reconcile"
+	// ReconcileAnnotation can be set on a Cluster or CareInstruction to trigger reconciliation of the matching Shoot(s).
+	ReconcileAnnotation = "shoot-grafter.cloudoperators.dev/reconcile"
 
 	// ShootStatusOnboarded indicates the shoot has been onboarded as a Greenhouse Cluster.
 	ShootStatusOnboarded = "Onboarded"

--- a/api/v1alpha1/careinstruction_types.go
+++ b/api/v1alpha1/careinstruction_types.go
@@ -39,7 +39,8 @@ const (
 	// AuthConfigMapLabel is the label used to identify AuthenticationConfiguration ConfigMaps
 	AuthConfigMapLabel = "shoot-grafter.cloudoperators.dev/auth-configmap"
 
-	// ReconcileAnnotation is the annotation set on a Greenhouse Cluster to trigger reconciliation of the matching Shoot.
+	// ReconcileAnnotation can be set on a Greenhouse Cluster or CareInstruction to trigger reconciliation
+	// of the matching Shoot(s).
 	ReconcileAnnotation = "greenhouse.sap/reconcile"
 
 	// ShootStatusOnboarded indicates the shoot has been onboarded as a Greenhouse Cluster.

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -531,6 +531,7 @@ func (r *CareInstructionReconciler) reconcileClusterReconcileAnnotations(ctx con
 	garden, exists := r.gardens[gardenKey]
 	r.gardensMu.RUnlock()
 	if !exists || garden.gardenClient == nil || garden.careInstructionSpec == nil {
+		r.Info("Garden client not ready, skipping Cluster reconcile annotation processing", "careInstruction", careInstruction.Name)
 		return nil
 	}
 	gardenClient := *garden.gardenClient
@@ -582,11 +583,7 @@ func (r *CareInstructionReconciler) reconcileAuthConfigMapChange(ctx context.Con
 		return client.IgnoreNotFound(err)
 	}
 
-	r.gardensMu.RLock()
-	lastRevision := r.gardens[gardenKey].authConfigMapRevision
-	r.gardensMu.RUnlock()
-
-	if cm.ResourceVersion == lastRevision {
+	if cm.ResourceVersion == garden.authConfigMapRevision {
 		return nil
 	}
 
@@ -628,6 +625,7 @@ func (r *CareInstructionReconciler) reconcileCareInstructionReconcileAnnotation(
 	garden, exists := r.gardens[gardenKey]
 	r.gardensMu.RUnlock()
 	if !exists || garden.gardenClient == nil || garden.careInstructionSpec == nil {
+		r.Info("Garden client not ready, skipping CareInstruction reconcile annotation processing", "careInstruction", careInstruction.Name)
 		return nil
 	}
 	gardenClient := *garden.gardenClient

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -390,7 +390,7 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 	r.gardensMu.RUnlock()
 
 	// Handle CareInstruction reconcile annotation: restart the shoot controller so it re-applies all config.
-	if _, hasAnnotation := careInstruction.Annotations[v1alpha1.ReconcileAnnotation]; hasAnnotation {
+	if careInstruction.Annotations[v1alpha1.ReconcileAnnotation] == "true" {
 		base := careInstruction.DeepCopy()
 		delete(careInstruction.Annotations, v1alpha1.ReconcileAnnotation)
 		if err := r.Patch(ctx, careInstruction, client.MergeFrom(base)); err != nil {
@@ -492,7 +492,7 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 		careInstruction.Status.Shoots = append(careInstruction.Status.Shoots, shootStatus)
 
 		// Handle Cluster reconcile annotation: annotate the matching Shoot and remove the annotation.
-		if _, hasAnnotation := cluster.Annotations[v1alpha1.ReconcileAnnotation]; hasAnnotation {
+		if cluster.Annotations[v1alpha1.ReconcileAnnotation] == "true" {
 			gardenNamespace := careInstruction.Spec.GardenNamespace
 			if err := shoot.AnnotateShootForReconcile(ctx, *gardenClient, gardenNamespace, cluster.Name); err != nil {
 				r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", cluster.Name)

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -587,23 +587,8 @@ func (r *CareInstructionReconciler) reconcileAuthConfigMapChange(ctx context.Con
 		return nil
 	}
 
-	gardenClient := *garden.gardenClient
-	shoots, err := careInstruction.ListShoots(ctx, gardenClient)
-	if err != nil {
+	if err := r.annotateMatchingShoots(ctx, careInstruction, *garden.gardenClient, "auth ConfigMap change"); err != nil {
 		return err
-	}
-
-	for i := range shoots.Items {
-		s := &shoots.Items[i]
-		matches, err := careInstruction.MatchesCELFilter(s)
-		if err != nil || !matches {
-			continue
-		}
-		if err := shoot.AnnotateShootForReconcile(ctx, gardenClient, s.Name, s.Namespace); err != nil {
-			r.Error(err, "failed to annotate Shoot for reconciliation after auth ConfigMap change", "shoot", s.Name)
-			continue
-		}
-		r.Info("Annotated Shoot for reconciliation after auth ConfigMap change", "shoot", s.Name)
 	}
 
 	r.gardensMu.Lock()
@@ -628,8 +613,19 @@ func (r *CareInstructionReconciler) reconcileCareInstructionReconcileAnnotation(
 		r.Info("Garden client not ready, skipping CareInstruction reconcile annotation processing", "careInstruction", careInstruction.Name)
 		return nil
 	}
-	gardenClient := *garden.gardenClient
 
+	if err := r.annotateMatchingShoots(ctx, careInstruction, *garden.gardenClient, "CareInstruction reconcile annotation"); err != nil {
+		return err
+	}
+
+	base := careInstruction.DeepCopy()
+	delete(careInstruction.Annotations, v1alpha1.ReconcileAnnotation)
+	return r.Patch(ctx, careInstruction, client.MergeFrom(base))
+}
+
+// annotateMatchingShoots sets gardener.cloud/operation=reconcile on all Shoots matched by the
+// CareInstruction's selector and CEL filter. reason is included in log messages.
+func (r *CareInstructionReconciler) annotateMatchingShoots(ctx context.Context, careInstruction *v1alpha1.CareInstruction, gardenClient client.Client, reason string) error {
 	shoots, err := careInstruction.ListShoots(ctx, gardenClient)
 	if err != nil {
 		return err
@@ -642,15 +638,13 @@ func (r *CareInstructionReconciler) reconcileCareInstructionReconcileAnnotation(
 			continue
 		}
 		if err := shoot.AnnotateShootForReconcile(ctx, gardenClient, s.Name, s.Namespace); err != nil {
-			r.Error(err, "failed to annotate Shoot for reconciliation via CareInstruction annotation", "shoot", s.Name)
+			r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", s.Name, "reason", reason)
 			continue
 		}
-		r.Info("Annotated Shoot for reconciliation via CareInstruction annotation", "shoot", s.Name)
+		r.Info("Annotated Shoot for reconciliation", "shoot", s.Name, "reason", reason)
 	}
 
-	base := careInstruction.DeepCopy()
-	delete(careInstruction.Annotations, v1alpha1.ReconcileAnnotation)
-	return r.Patch(ctx, careInstruction, client.MergeFrom(base))
+	return nil
 }
 
 // cleanupCareInstruction - deletes the CareInstruction and cleans up any resources associated with it.

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -587,7 +587,8 @@ func (r *CareInstructionReconciler) reconcileAuthConfigMapChange(ctx context.Con
 		return nil
 	}
 
-	if err := r.annotateMatchingShoots(ctx, careInstruction, *garden.gardenClient, "auth ConfigMap change"); err != nil {
+	shoots, err := r.listMatchingShoots(ctx, careInstruction, *garden.gardenClient)
+	if err != nil {
 		return err
 	}
 
@@ -595,6 +596,14 @@ func (r *CareInstructionReconciler) reconcileAuthConfigMapChange(ctx context.Con
 	r.gardens[gardenKey].authConfigMapRevision = cm.ResourceVersion
 	r.gardensMu.Unlock()
 
+	for i := range shoots {
+		s := &shoots[i]
+		if err := shoot.AnnotateShootForReconcile(ctx, *garden.gardenClient, s.Name, s.Namespace); err != nil {
+			r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", s.Name, "reason", "auth ConfigMap change")
+			continue
+		}
+		r.Info("Annotated Shoot for reconciliation", "shoot", s.Name, "reason", "auth ConfigMap change")
+	}
 	return nil
 }
 
@@ -614,8 +623,17 @@ func (r *CareInstructionReconciler) reconcileCareInstructionReconcileAnnotation(
 		return nil
 	}
 
-	if err := r.annotateMatchingShoots(ctx, careInstruction, *garden.gardenClient, "CareInstruction reconcile annotation"); err != nil {
+	shoots, err := r.listMatchingShoots(ctx, careInstruction, *garden.gardenClient)
+	if err != nil {
 		return err
+	}
+	for i := range shoots {
+		s := &shoots[i]
+		if err := shoot.AnnotateShootForReconcile(ctx, *garden.gardenClient, s.Name, s.Namespace); err != nil {
+			r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", s.Name, "reason", "CareInstruction reconcile annotation")
+			continue
+		}
+		r.Info("Annotated Shoot for reconciliation", "shoot", s.Name, "reason", "CareInstruction reconcile annotation")
 	}
 
 	base := careInstruction.DeepCopy()
@@ -623,28 +641,22 @@ func (r *CareInstructionReconciler) reconcileCareInstructionReconcileAnnotation(
 	return r.Patch(ctx, careInstruction, client.MergeFrom(base))
 }
 
-// annotateMatchingShoots sets gardener.cloud/operation=reconcile on all Shoots matched by the
-// CareInstruction's selector and CEL filter. reason is included in log messages.
-func (r *CareInstructionReconciler) annotateMatchingShoots(ctx context.Context, careInstruction *v1alpha1.CareInstruction, gardenClient client.Client, reason string) error {
-	shoots, err := careInstruction.ListShoots(ctx, gardenClient)
+// listMatchingShoots returns all Shoots that pass the CareInstruction's label selector and CEL filter.
+func (r *CareInstructionReconciler) listMatchingShoots(ctx context.Context, careInstruction *v1alpha1.CareInstruction, gardenClient client.Client) ([]gardenerv1beta1.Shoot, error) {
+	all, err := careInstruction.ListShoots(ctx, gardenClient)
 	if err != nil {
-		return err
+		return nil, err
 	}
-
-	for i := range shoots.Items {
-		s := &shoots.Items[i]
+	var matched []gardenerv1beta1.Shoot
+	for i := range all.Items {
+		s := &all.Items[i]
 		matches, err := careInstruction.MatchesCELFilter(s)
 		if err != nil || !matches {
 			continue
 		}
-		if err := shoot.AnnotateShootForReconcile(ctx, gardenClient, s.Name, s.Namespace); err != nil {
-			r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", s.Name, "reason", reason)
-			continue
-		}
-		r.Info("Annotated Shoot for reconciliation", "shoot", s.Name, "reason", reason)
+		matched = append(matched, *s)
 	}
-
-	return nil
+	return matched, nil
 }
 
 // cleanupCareInstruction - deletes the CareInstruction and cleans up any resources associated with it.

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -135,10 +135,6 @@ func (r *CareInstructionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		return ctrl.Result{}, err
 	}
 
-	if err := r.reconcileAuthConfigMapChange(ctx, &careInstruction); err != nil {
-		r.Error(err, "failed to reconcile auth ConfigMap change")
-	}
-
 	// reconcile Shoots and Clusters created by this CareInstruction
 	if err := r.reconcileShootsNClusters(ctx, &careInstruction); err != nil {
 		r.Info("failed to reconcile shoots and clusters for CareInstruction, will retry", "error", err.Error())
@@ -152,11 +148,15 @@ func (r *CareInstructionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	if err := r.reconcileClusterReconcileAnnotations(ctx, &careInstruction); err != nil {
-		r.Error(err, "failed to reconcile cluster reconcile annotations")
+		return ctrl.Result{}, err
 	}
 
 	if err := r.reconcileCareInstructionReconcileAnnotation(ctx, &careInstruction); err != nil {
-		r.Error(err, "failed to reconcile careinstruction reconcile annotation")
+		return ctrl.Result{}, err
+	}
+
+	if err := r.reconcileAuthConfigMapChange(ctx, &careInstruction); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -173,19 +173,36 @@ func (r *CareInstructionReconciler) reconcileManager(ctx context.Context, careIn
 	// Use namespace-qualified key to prevent collisions between CareInstructions with the same name in different namespaces
 	gardenKey := careInstruction.Namespace + "/" + careInstruction.Name
 
-	// Initialize gardens map if needed (with write lock)
+	r.gardensMu.RLock()
+	_, gardenEntryExists := r.gardens[gardenKey]
+	r.gardensMu.RUnlock()
+
+	initialAuthCMRevision := ""
+	if !gardenEntryExists && careInstruction.Spec.AuthenticationConfigMapName != "" {
+		// Seed the revision so the first reconcile does not trigger a spurious controller restart.
+		var cm corev1.ConfigMap
+		if err := r.Get(ctx, client.ObjectKey{
+			Namespace: careInstruction.Namespace,
+			Name:      careInstruction.Spec.AuthenticationConfigMapName,
+		}, &cm); err == nil {
+			initialAuthCMRevision = cm.ResourceVersion
+		}
+	}
+
+	// Initialize gardens map if needed.
 	r.gardensMu.Lock()
 	if r.gardens == nil {
 		r.gardens = make(map[string]*garden)
 	}
 	if _, exists := r.gardens[gardenKey]; !exists {
 		r.gardens[gardenKey] = &garden{
-			mgr:                 nil,
-			gardenConfig:        nil,
-			gardenClient:        nil,
-			careInstructionSpec: &careInstruction.Spec,
-			cancelFunc:          nil,
-			stopChan:            nil,
+			mgr:                   nil,
+			gardenConfig:          nil,
+			gardenClient:          nil,
+			careInstructionSpec:   &careInstruction.Spec,
+			cancelFunc:            nil,
+			stopChan:              nil,
+			authConfigMapRevision: initialAuthCMRevision,
 		}
 	}
 	r.gardensMu.Unlock()
@@ -360,6 +377,7 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 	careInstruction.Status.CreatedClusters = 0
 	careInstruction.Status.FailedClusters = 0
 	careInstruction.Status.Shoots = []v1alpha1.ShootStatus{}
+	defer UpdateCareInstructionMetrics(careInstruction)
 
 	// Get garden client (with read lock)
 	gardenKey := careInstruction.Namespace + "/" + careInstruction.Name
@@ -427,8 +445,6 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 			r.restartShootController(careInstruction)
 		}
 	}
-
-	defer UpdateCareInstructionMetrics(careInstruction)
 
 	// List all clusters created by this CareInstruction
 	clusters, err := careInstruction.ListClusters(ctx, r.Client)

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -5,8 +5,12 @@ package careinstruction
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
+	"fmt"
 	"reflect"
+	"sort"
 	"sync"
 
 	"shoot-grafter/api/v1alpha1"
@@ -46,13 +50,13 @@ type CareInstructionReconciler struct {
 }
 
 type garden struct {
-	mgr                   ctrl.Manager                  // The manager for the garden cluster
-	gardenConfig          *rest.Config                  // The REST config for the garden cluster
-	gardenClient          *client.Client                // The client for the garden cluster
-	careInstructionSpec   *v1alpha1.CareInstructionSpec // The CareInstruction object for the garden cluster
-	cancelFunc            context.CancelFunc            // Cancel function to stop the manager
-	stopChan              chan bool                     // Channel to know if the manager is stopped
-	authConfigMapRevision string                        // ResourceVersion of the last-seen auth ConfigMap
+	mgr                 ctrl.Manager                  // The manager for the garden cluster
+	gardenConfig        *rest.Config                  // The REST config for the garden cluster
+	gardenClient        *client.Client                // The client for the garden cluster
+	careInstructionSpec *v1alpha1.CareInstructionSpec // The CareInstruction object for the garden cluster
+	cancelFunc          context.CancelFunc            // Cancel function to stop the manager
+	stopChan            chan bool                     // Channel to know if the manager is stopped
+	authConfigMapHash   string                        // SHA-256 hash of the last-seen auth ConfigMap data
 }
 
 type careInstructionContextKey struct{}
@@ -177,15 +181,15 @@ func (r *CareInstructionReconciler) reconcileManager(ctx context.Context, careIn
 	_, gardenEntryExists := r.gardens[gardenKey]
 	r.gardensMu.RUnlock()
 
-	initialAuthCMRevision := ""
+	initialAuthCMHash := ""
 	if !gardenEntryExists && careInstruction.Spec.AuthenticationConfigMapName != "" {
-		// Seed the revision so the first reconcile does not trigger a spurious controller restart.
+		// Seed the hash so the first reconcile does not trigger an unnecessary controller restart.
 		var cm corev1.ConfigMap
 		if err := r.Get(ctx, client.ObjectKey{
 			Namespace: careInstruction.Namespace,
 			Name:      careInstruction.Spec.AuthenticationConfigMapName,
 		}, &cm); err == nil {
-			initialAuthCMRevision = cm.ResourceVersion
+			initialAuthCMHash = hashAuthConfigMap(&cm)
 		}
 	}
 
@@ -196,13 +200,13 @@ func (r *CareInstructionReconciler) reconcileManager(ctx context.Context, careIn
 	}
 	if _, exists := r.gardens[gardenKey]; !exists {
 		r.gardens[gardenKey] = &garden{
-			mgr:                   nil,
-			gardenConfig:          nil,
-			gardenClient:          nil,
-			careInstructionSpec:   &careInstruction.Spec,
-			cancelFunc:            nil,
-			stopChan:              nil,
-			authConfigMapRevision: initialAuthCMRevision,
+			mgr:                 nil,
+			gardenConfig:        nil,
+			gardenClient:        nil,
+			careInstructionSpec: &careInstruction.Spec,
+			cancelFunc:          nil,
+			stopChan:            nil,
+			authConfigMapHash:   initialAuthCMHash,
 		}
 	}
 	r.gardensMu.Unlock()
@@ -438,11 +442,13 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 			Name:      careInstruction.Spec.AuthenticationConfigMapName,
 		}, &cm); err != nil && !apierrors.IsNotFound(err) {
 			return err
-		} else if err == nil && cm.ResourceVersion != garden.authConfigMapRevision {
-			r.gardensMu.Lock()
-			r.gardens[gardenKey].authConfigMapRevision = cm.ResourceVersion
-			r.gardensMu.Unlock()
-			r.restartShootController(careInstruction)
+		} else if err == nil {
+			if h := hashAuthConfigMap(&cm); h != garden.authConfigMapHash {
+				r.gardensMu.Lock()
+				r.gardens[gardenKey].authConfigMapHash = h
+				r.gardensMu.Unlock()
+				r.restartShootController(careInstruction)
+			}
 		}
 	}
 
@@ -645,6 +651,20 @@ func (r *CareInstructionReconciler) ensureAuthConfigMapLabeled(ctx context.Conte
 	}
 	cm.Labels[v1alpha1.AuthConfigMapLabel] = "true"
 	return r.Patch(ctx, &cm, client.MergeFrom(base))
+}
+
+// hashAuthConfigMap returns a SHA-256 hash of the auth ConfigMap's data, used to detect data-only changes.
+func hashAuthConfigMap(cm *corev1.ConfigMap) string {
+	keys := make([]string, 0, len(cm.Data))
+	for k := range cm.Data {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	h := sha256.New()
+	for _, k := range keys {
+		fmt.Fprintf(h, "%s=%s\n", k, cm.Data[k])
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // enqueueCareInstructionForGardenCluster - enqueues the CareInstruction for the given Garden Cluster.

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -530,8 +530,8 @@ func (r *CareInstructionReconciler) reconcileClusterReconcileAnnotations(ctx con
 	garden, exists := r.gardens[gardenKey]
 	r.gardensMu.RUnlock()
 	if !exists || garden.gardenClient == nil || garden.careInstructionSpec == nil {
-		r.Info("Garden client not ready, skipping Cluster reconcile annotation processing", "careInstruction", careInstruction.Name)
-		return nil
+		// TODO: set a status condition here once trigger failures are reported via ShootsReconciled condition
+		return errors.New("garden client not ready, cannot process Cluster reconcile annotations")
 	}
 	gardenClient := *garden.gardenClient
 	gardenNamespace := garden.careInstructionSpec.GardenNamespace
@@ -559,8 +559,7 @@ func (r *CareInstructionReconciler) reconcileClusterReconcileAnnotations(ctx con
 }
 
 // reconcileAuthConfigMapChange detects when the auth ConfigMap's data has changed since the last
-// reconcile and fans out gardener.cloud/operation=reconcile to all matching Shoots so they pick up
-// the new OIDC configuration.
+// reconcile and restarts the shoot controller so it re-applies the new OIDC configuration to all Shoots.
 func (r *CareInstructionReconciler) reconcileAuthConfigMapChange(ctx context.Context, careInstruction *v1alpha1.CareInstruction) error {
 	if careInstruction.Spec.AuthenticationConfigMapName == "" {
 		return nil
@@ -586,80 +585,41 @@ func (r *CareInstructionReconciler) reconcileAuthConfigMapChange(ctx context.Con
 		return nil
 	}
 
-	shoots, err := r.listMatchingShoots(ctx, careInstruction, *garden.gardenClient)
-	if err != nil {
-		return err
-	}
-
 	r.gardensMu.Lock()
 	r.gardens[gardenKey].authConfigMapRevision = cm.ResourceVersion
 	r.gardensMu.Unlock()
 
-	for i := range shoots {
-		s := &shoots[i]
-		if err := shoot.AnnotateShootForReconcile(ctx, *garden.gardenClient, s.Namespace, s.Name); err != nil {
-			r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", s.Name, "reason", "auth ConfigMap change")
-			continue
-		}
-		r.Info("Annotated Shoot for reconciliation", "shoot", s.Name, "reason", "auth ConfigMap change")
-	}
+	r.restartShootController(careInstruction)
 	return nil
 }
 
-// reconcileCareInstructionReconcileAnnotation fans out gardener.cloud/operation=reconcile to all matching Shoots
-// when greenhouse.sap/reconcile is set on the CareInstruction, then removes the annotation.
+// reconcileCareInstructionReconcileAnnotation restarts the shoot controller when the ReconcileAnnotation
+// is set on the CareInstruction, then removes the annotation. Restarting the controller ensures all
+// shoot-grafter config (auth, labels) is re-applied to all matching Shoots.
 func (r *CareInstructionReconciler) reconcileCareInstructionReconcileAnnotation(ctx context.Context, careInstruction *v1alpha1.CareInstruction) error {
 	if _, hasAnnotation := careInstruction.Annotations[v1alpha1.ReconcileAnnotation]; !hasAnnotation {
 		return nil
 	}
 
-	gardenKey := careInstruction.Namespace + "/" + careInstruction.Name
-	r.gardensMu.RLock()
-	garden, exists := r.gardens[gardenKey]
-	r.gardensMu.RUnlock()
-	if !exists || garden.gardenClient == nil || garden.careInstructionSpec == nil {
-		r.Info("Garden client not ready, skipping CareInstruction reconcile annotation processing", "careInstruction", careInstruction.Name)
-		return nil
-	}
-
-	shoots, err := r.listMatchingShoots(ctx, careInstruction, *garden.gardenClient)
-	if err != nil {
-		return err
-	}
-	for i := range shoots {
-		s := &shoots[i]
-		if err := shoot.AnnotateShootForReconcile(ctx, *garden.gardenClient, s.Namespace, s.Name); err != nil {
-			r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", s.Name, "reason", "CareInstruction reconcile annotation")
-			continue
-		}
-		r.Info("Annotated Shoot for reconciliation", "shoot", s.Name, "reason", "CareInstruction reconcile annotation")
-	}
+	r.restartShootController(careInstruction)
 
 	base := careInstruction.DeepCopy()
 	delete(careInstruction.Annotations, v1alpha1.ReconcileAnnotation)
 	return r.Patch(ctx, careInstruction, client.MergeFrom(base))
 }
 
-// listMatchingShoots returns all Shoots that pass the CareInstruction's label selector and CEL filter.
-func (r *CareInstructionReconciler) listMatchingShoots(ctx context.Context, careInstruction *v1alpha1.CareInstruction, gardenClient client.Client) ([]gardenerv1beta1.Shoot, error) {
-	all, err := careInstruction.ListShoots(ctx, gardenClient)
-	if err != nil {
-		return nil, err
+// restartShootController cancels the garden manager for the given CareInstruction so that
+// reconcileManager recreates it on the next reconcile, re-applying all shoot-grafter config.
+func (r *CareInstructionReconciler) restartShootController(careInstruction *v1alpha1.CareInstruction) {
+	gardenKey := careInstruction.Namespace + "/" + careInstruction.Name
+	r.gardensMu.RLock()
+	garden, exists := r.gardens[gardenKey]
+	r.gardensMu.RUnlock()
+	if !exists || garden.cancelFunc == nil {
+		return
 	}
-	var matched []gardenerv1beta1.Shoot
-	for i := range all.Items {
-		s := &all.Items[i]
-		matches, err := careInstruction.MatchesCELFilter(s)
-		if err != nil {
-			r.Error(err, "CEL filter evaluation failed, skipping Shoot", "shoot", s.Name)
-			continue
-		}
-		if !matches {
-			continue
-		}
-		matched = append(matched, *s)
-	}
-	return matched, nil
+	r.Info("Restarting shoot controller", "careInstruction", careInstruction.Name)
+	garden.cancelFunc()
 }
 
 // cleanupCareInstruction - deletes the CareInstruction and cleans up any resources associated with it.

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -588,10 +588,13 @@ func (r *CareInstructionReconciler) restartShootController(careInstruction *v1al
 		return
 	}
 	r.Info("Restarting shoot controller", "careInstruction", careInstruction.Name)
+	alreadyStopped := garden.mgr == nil
 	garden.cancelFunc()
 	garden.mgr = nil
 	r.gardensMu.Unlock()
-	careInstruction.Status.ShootControllerRestartCount++
+	if !alreadyStopped {
+		careInstruction.Status.ShootControllerRestartCount++
+	}
 }
 
 // cleanupCareInstruction - deletes the CareInstruction and cleans up any resources associated with it.

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -494,7 +494,7 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 
 		// Handle Cluster reconcile annotation: annotate the matching Shoot and remove the annotation.
 		if _, hasAnnotation := cluster.Annotations[v1alpha1.ReconcileAnnotation]; hasAnnotation {
-			gardenNamespace := garden.careInstructionSpec.GardenNamespace
+			gardenNamespace := careInstruction.Spec.GardenNamespace
 			if err := shoot.AnnotateShootForReconcile(ctx, *gardenClient, gardenNamespace, cluster.Name); err != nil {
 				r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", cluster.Name)
 				retErr = err

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -388,12 +388,12 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 
 	// Handle CareInstruction reconcile annotation: restart the shoot controller so it re-applies all config.
 	if _, hasAnnotation := careInstruction.Annotations[v1alpha1.ReconcileAnnotation]; hasAnnotation {
-		r.restartShootController(careInstruction)
 		base := careInstruction.DeepCopy()
 		delete(careInstruction.Annotations, v1alpha1.ReconcileAnnotation)
 		if err := r.Patch(ctx, careInstruction, client.MergeFrom(base)); err != nil {
 			return err
 		}
+		r.restartShootController(careInstruction)
 	}
 
 	// List all shoots targeted by this CareInstruction
@@ -577,6 +577,7 @@ func (r *CareInstructionReconciler) restartShootController(careInstruction *v1al
 	garden.cancelFunc()
 	garden.mgr = nil
 	r.gardensMu.Unlock()
+	careInstruction.Status.ShootControllerRestartCount++
 }
 
 // cleanupCareInstruction - deletes the CareInstruction and cleans up any resources associated with it.

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -147,10 +147,6 @@ func (r *CareInstructionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		)
 	}
 
-	if err := r.reconcileCareInstructionReconcileAnnotation(ctx, &careInstruction); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	if err := r.reconcileAuthConfigMapChange(ctx, &careInstruction); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -376,6 +372,16 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 	gardenClient := garden.gardenClient
 	r.gardensMu.RUnlock()
 
+	// Handle CareInstruction reconcile annotation: restart the shoot controller so it re-applies all config.
+	if _, hasAnnotation := careInstruction.Annotations[v1alpha1.ReconcileAnnotation]; hasAnnotation {
+		r.restartShootController(careInstruction)
+		base := careInstruction.DeepCopy()
+		delete(careInstruction.Annotations, v1alpha1.ReconcileAnnotation)
+		if err := r.Patch(ctx, careInstruction, client.MergeFrom(base)); err != nil {
+			return err
+		}
+	}
+
 	// List all shoots targeted by this CareInstruction
 	shoots, err := careInstruction.ListShoots(ctx, *gardenClient)
 	if client.IgnoreNotFound(err) != nil {
@@ -562,21 +568,6 @@ func (r *CareInstructionReconciler) reconcileAuthConfigMapChange(ctx context.Con
 
 	r.restartShootController(careInstruction)
 	return nil
-}
-
-// reconcileCareInstructionReconcileAnnotation restarts the shoot controller when the ReconcileAnnotation
-// is set on the CareInstruction, then removes the annotation. Restarting the controller ensures all
-// shoot-grafter config (auth, labels) is re-applied to all matching Shoots.
-func (r *CareInstructionReconciler) reconcileCareInstructionReconcileAnnotation(ctx context.Context, careInstruction *v1alpha1.CareInstruction) error {
-	if _, hasAnnotation := careInstruction.Annotations[v1alpha1.ReconcileAnnotation]; !hasAnnotation {
-		return nil
-	}
-
-	r.restartShootController(careInstruction)
-
-	base := careInstruction.DeepCopy()
-	delete(careInstruction.Annotations, v1alpha1.ReconcileAnnotation)
-	return r.Patch(ctx, careInstruction, client.MergeFrom(base))
 }
 
 // restartShootController cancels the garden manager for the given CareInstruction so that

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -543,11 +543,11 @@ func (r *CareInstructionReconciler) reconcileClusterReconcileAnnotations(ctx con
 			continue
 		}
 
-		if err := shoot.AnnotateShootForReconcile(ctx, gardenClient, cluster.Name, gardenNamespace); err != nil {
+		if err := shoot.AnnotateShootForReconcile(ctx, gardenClient, gardenNamespace, cluster.Name); err != nil {
 			r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", cluster.Name)
 			continue
 		}
-		r.Info("Annotated Shoot for reconciliation via Cluster annotation", "shoot", cluster.Name, "cluster", cluster.Name)
+		r.Info("Annotated Shoot for reconciliation via Cluster annotation", "shoot", cluster.Name)
 
 		base := cluster.DeepCopy()
 		delete(cluster.Annotations, v1alpha1.ReconcileAnnotation)
@@ -598,7 +598,7 @@ func (r *CareInstructionReconciler) reconcileAuthConfigMapChange(ctx context.Con
 
 	for i := range shoots {
 		s := &shoots[i]
-		if err := shoot.AnnotateShootForReconcile(ctx, *garden.gardenClient, s.Name, s.Namespace); err != nil {
+		if err := shoot.AnnotateShootForReconcile(ctx, *garden.gardenClient, s.Namespace, s.Name); err != nil {
 			r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", s.Name, "reason", "auth ConfigMap change")
 			continue
 		}
@@ -629,7 +629,7 @@ func (r *CareInstructionReconciler) reconcileCareInstructionReconcileAnnotation(
 	}
 	for i := range shoots {
 		s := &shoots[i]
-		if err := shoot.AnnotateShootForReconcile(ctx, *garden.gardenClient, s.Name, s.Namespace); err != nil {
+		if err := shoot.AnnotateShootForReconcile(ctx, *garden.gardenClient, s.Namespace, s.Name); err != nil {
 			r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", s.Name, "reason", "CareInstruction reconcile annotation")
 			continue
 		}

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -70,6 +70,7 @@ func (r *CareInstructionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&v1alpha1.CareInstruction{}).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.enqueueCareInstructionForGardenCluster), builder.WithPredicates(clientutil.PredicateFilterBySecretTypes(greenhouseapis.SecretTypeKubeConfig, greenhouseapis.SecretTypeOIDCConfig))).
 		Watches(&greenhousev1alpha1.Cluster{}, handler.EnqueueRequestsFromMapFunc(r.enqueueCareInstructionForCreatedClusters), builder.WithPredicates(clientutil.PredicateHasLabel(v1alpha1.CareInstructionLabel))).
+		Watches(&greenhousev1alpha1.Cluster{}, handler.EnqueueRequestsFromMapFunc(r.enqueueCareInstructionForClusterReconcileAnnotation), builder.WithPredicates(clientutil.PredicateHasLabel(v1alpha1.CareInstructionLabel), clientutil.PredicateAnnotationAddedOrUpdated(v1alpha1.ReconcileAnnotation))).
 		// Watch auth ConfigMaps; on data change, re-enqueue referencing CareInstructions.
 		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.enqueueCareInstructionForAuthConfigMap),
 			builder.WithPredicates(
@@ -144,6 +145,10 @@ func (r *CareInstructionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 				err.Error(),
 			),
 		)
+	}
+
+	if err := r.reconcileClusterReconcileAnnotations(ctx, &careInstruction); err != nil {
+		r.Error(err, "failed to reconcile cluster reconcile annotations")
 	}
 
 	return ctrl.Result{}, nil
@@ -503,6 +508,47 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 	return nil
 }
 
+// reconcileClusterReconcileAnnotations finds Clusters owned by this CareInstruction that have the
+// greenhouse.sap/reconcile annotation, sets gardener.cloud/operation=reconcile on the matching Shoot,
+// and removes the annotation from the Cluster.
+func (r *CareInstructionReconciler) reconcileClusterReconcileAnnotations(ctx context.Context, careInstruction *v1alpha1.CareInstruction) error {
+	clusters, err := careInstruction.ListClusters(ctx, r.Client)
+	if err != nil {
+		return err
+	}
+
+	gardenKey := careInstruction.Namespace + "/" + careInstruction.Name
+	r.gardensMu.RLock()
+	garden, exists := r.gardens[gardenKey]
+	r.gardensMu.RUnlock()
+	if !exists || garden.gardenClient == nil || garden.careInstructionSpec == nil {
+		return nil
+	}
+	gardenClient := *garden.gardenClient
+	gardenNamespace := garden.careInstructionSpec.GardenNamespace
+
+	for i := range clusters.Items {
+		cluster := &clusters.Items[i]
+		if _, hasAnnotation := cluster.Annotations[v1alpha1.ReconcileAnnotation]; !hasAnnotation {
+			continue
+		}
+
+		if err := shoot.AnnotateShootForReconcile(ctx, gardenClient, cluster.Name, gardenNamespace); err != nil {
+			r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", cluster.Name)
+			continue
+		}
+		r.Info("Annotated Shoot for reconciliation via Cluster annotation", "shoot", cluster.Name, "cluster", cluster.Name)
+
+		base := cluster.DeepCopy()
+		delete(cluster.Annotations, v1alpha1.ReconcileAnnotation)
+		if err := r.Patch(ctx, cluster, client.MergeFrom(base)); err != nil {
+			r.Error(err, "failed to remove reconcile annotation from Cluster", "cluster", cluster.Name)
+		}
+	}
+
+	return nil
+}
+
 // cleanupCareInstruction - deletes the CareInstruction and cleans up any resources associated with it.
 func (r *CareInstructionReconciler) cleanupCareInstruction(ctx context.Context, careInstruction *v1alpha1.CareInstruction) error {
 	r.Info("Cleaning up CareInstruction", "name", careInstruction.Name, "namespace", careInstruction.Namespace)
@@ -627,6 +673,22 @@ func (r *CareInstructionReconciler) enqueueCareInstructionForCreatedClusters(_ c
 			},
 		},
 	}
+}
+
+// enqueueCareInstructionForClusterReconcileAnnotation enqueues the owning CareInstruction when greenhouse.sap/reconcile
+// is added or updated on a Greenhouse Cluster. The actual Shoot annotation is applied in Reconcile.
+func (r *CareInstructionReconciler) enqueueCareInstructionForClusterReconcileAnnotation(_ context.Context, obj client.Object) []ctrl.Request {
+	cluster, ok := obj.(*greenhousev1alpha1.Cluster)
+	if !ok {
+		return nil
+	}
+
+	careInstructionName, exists := cluster.Labels[v1alpha1.CareInstructionLabel]
+	if !exists {
+		return nil
+	}
+
+	return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: careInstructionName, Namespace: cluster.Namespace}}}
 }
 
 // enqueueCareInstructionForAuthConfigMap enqueues all CareInstructions in the same namespace that reference

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -151,6 +151,10 @@ func (r *CareInstructionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		r.Error(err, "failed to reconcile cluster reconcile annotations")
 	}
 
+	if err := r.reconcileCareInstructionReconcileAnnotation(ctx, &careInstruction); err != nil {
+		r.Error(err, "failed to reconcile careinstruction reconcile annotation")
+	}
+
 	return ctrl.Result{}, nil
 }
 
@@ -547,6 +551,45 @@ func (r *CareInstructionReconciler) reconcileClusterReconcileAnnotations(ctx con
 	}
 
 	return nil
+}
+
+// reconcileCareInstructionReconcileAnnotation fans out gardener.cloud/operation=reconcile to all matching Shoots
+// when greenhouse.sap/reconcile is set on the CareInstruction, then removes the annotation.
+func (r *CareInstructionReconciler) reconcileCareInstructionReconcileAnnotation(ctx context.Context, careInstruction *v1alpha1.CareInstruction) error {
+	if _, hasAnnotation := careInstruction.Annotations[v1alpha1.ReconcileAnnotation]; !hasAnnotation {
+		return nil
+	}
+
+	gardenKey := careInstruction.Namespace + "/" + careInstruction.Name
+	r.gardensMu.RLock()
+	garden, exists := r.gardens[gardenKey]
+	r.gardensMu.RUnlock()
+	if !exists || garden.gardenClient == nil || garden.careInstructionSpec == nil {
+		return nil
+	}
+	gardenClient := *garden.gardenClient
+
+	shoots, err := careInstruction.ListShoots(ctx, gardenClient)
+	if err != nil {
+		return err
+	}
+
+	for i := range shoots.Items {
+		s := &shoots.Items[i]
+		matches, err := careInstruction.MatchesCELFilter(s)
+		if err != nil || !matches {
+			continue
+		}
+		if err := shoot.AnnotateShootForReconcile(ctx, gardenClient, s.Name, s.Namespace); err != nil {
+			r.Error(err, "failed to annotate Shoot for reconciliation via CareInstruction annotation", "shoot", s.Name)
+			continue
+		}
+		r.Info("Annotated Shoot for reconciliation via CareInstruction annotation", "shoot", s.Name)
+	}
+
+	base := careInstruction.DeepCopy()
+	delete(careInstruction.Annotations, v1alpha1.ReconcileAnnotation)
+	return r.Patch(ctx, careInstruction, client.MergeFrom(base))
 }
 
 // cleanupCareInstruction - deletes the CareInstruction and cleans up any resources associated with it.

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -650,7 +650,11 @@ func (r *CareInstructionReconciler) listMatchingShoots(ctx context.Context, care
 	for i := range all.Items {
 		s := &all.Items[i]
 		matches, err := careInstruction.MatchesCELFilter(s)
-		if err != nil || !matches {
+		if err != nil {
+			r.Error(err, "CEL filter evaluation failed, skipping Shoot", "shoot", s.Name)
+			continue
+		}
+		if !matches {
 			continue
 		}
 		matched = append(matched, *s)

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -147,10 +147,6 @@ func (r *CareInstructionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		)
 	}
 
-	if err := r.reconcileAuthConfigMapChange(ctx, &careInstruction); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	return ctrl.Result{}, nil
 }
 
@@ -416,6 +412,22 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 		}
 	}
 
+	// Handle auth ConfigMap change: restart the shoot controller when CM data changes.
+	if careInstruction.Spec.AuthenticationConfigMapName != "" {
+		var cm corev1.ConfigMap
+		if err := r.Get(ctx, client.ObjectKey{
+			Namespace: careInstruction.Namespace,
+			Name:      careInstruction.Spec.AuthenticationConfigMapName,
+		}, &cm); err != nil && !apierrors.IsNotFound(err) {
+			return err
+		} else if err == nil && cm.ResourceVersion != garden.authConfigMapRevision {
+			r.gardensMu.Lock()
+			r.gardens[gardenKey].authConfigMapRevision = cm.ResourceVersion
+			r.gardensMu.Unlock()
+			r.restartShootController(careInstruction)
+		}
+	}
+
 	defer UpdateCareInstructionMetrics(careInstruction)
 
 	// List all clusters created by this CareInstruction
@@ -532,41 +544,6 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 		),
 	)
 
-	return nil
-}
-
-// reconcileAuthConfigMapChange detects when the auth ConfigMap's data has changed since the last
-// reconcile and restarts the shoot controller so it re-applies the new OIDC configuration to all Shoots.
-func (r *CareInstructionReconciler) reconcileAuthConfigMapChange(ctx context.Context, careInstruction *v1alpha1.CareInstruction) error {
-	if careInstruction.Spec.AuthenticationConfigMapName == "" {
-		return nil
-	}
-
-	gardenKey := careInstruction.Namespace + "/" + careInstruction.Name
-	r.gardensMu.RLock()
-	garden, exists := r.gardens[gardenKey]
-	r.gardensMu.RUnlock()
-	if !exists || garden.gardenClient == nil {
-		return nil
-	}
-
-	var cm corev1.ConfigMap
-	if err := r.Get(ctx, client.ObjectKey{
-		Namespace: careInstruction.Namespace,
-		Name:      careInstruction.Spec.AuthenticationConfigMapName,
-	}, &cm); err != nil {
-		return client.IgnoreNotFound(err)
-	}
-
-	if cm.ResourceVersion == garden.authConfigMapRevision {
-		return nil
-	}
-
-	r.gardensMu.Lock()
-	r.gardens[gardenKey].authConfigMapRevision = cm.ResourceVersion
-	r.gardensMu.Unlock()
-
-	r.restartShootController(careInstruction)
 	return nil
 }
 

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -147,10 +147,6 @@ func (r *CareInstructionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		)
 	}
 
-	if err := r.reconcileClusterReconcileAnnotations(ctx, &careInstruction); err != nil {
-		return ctrl.Result{}, err
-	}
-
 	if err := r.reconcileCareInstructionReconcileAnnotation(ctx, &careInstruction); err != nil {
 		return ctrl.Result{}, err
 	}
@@ -376,7 +372,8 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 	// Get garden client (with read lock)
 	gardenKey := careInstruction.Namespace + "/" + careInstruction.Name
 	r.gardensMu.RLock()
-	gardenClient := r.gardens[gardenKey].gardenClient
+	garden := r.gardens[gardenKey]
+	gardenClient := garden.gardenClient
 	r.gardensMu.RUnlock()
 
 	// List all shoots targeted by this CareInstruction
@@ -432,7 +429,8 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 		existingClusterNames[cluster.Name] = true
 	}
 
-	for _, cluster := range clusters.Items {
+	for i := range clusters.Items {
+		cluster := &clusters.Items[i]
 		shootStatus := v1alpha1.ShootStatus{
 			Name: cluster.Name,
 		}
@@ -449,6 +447,21 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 		}
 
 		careInstruction.Status.Shoots = append(careInstruction.Status.Shoots, shootStatus)
+
+		// Handle Cluster reconcile annotation: annotate the matching Shoot and remove the annotation.
+		if _, hasAnnotation := cluster.Annotations[v1alpha1.ReconcileAnnotation]; hasAnnotation {
+			gardenNamespace := garden.careInstructionSpec.GardenNamespace
+			if err := shoot.AnnotateShootForReconcile(ctx, *gardenClient, gardenNamespace, cluster.Name); err != nil {
+				r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", cluster.Name)
+			} else {
+				r.Info("Annotated Shoot for reconciliation via Cluster annotation", "shoot", cluster.Name)
+				base := cluster.DeepCopy()
+				delete(cluster.Annotations, v1alpha1.ReconcileAnnotation)
+				if err := r.Patch(ctx, cluster, client.MergeFrom(base)); err != nil {
+					r.Error(err, "failed to remove reconcile annotation from Cluster", "cluster", cluster.Name)
+				}
+			}
+		}
 	}
 
 	effectiveShootCount := len(includedShoots)
@@ -512,48 +525,6 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 			"All shoots and clusters are reconciled",
 		),
 	)
-
-	return nil
-}
-
-// reconcileClusterReconcileAnnotations finds Clusters owned by this CareInstruction that have the
-// greenhouse.sap/reconcile annotation, sets gardener.cloud/operation=reconcile on the matching Shoot,
-// and removes the annotation from the Cluster.
-func (r *CareInstructionReconciler) reconcileClusterReconcileAnnotations(ctx context.Context, careInstruction *v1alpha1.CareInstruction) error {
-	clusters, err := careInstruction.ListClusters(ctx, r.Client)
-	if err != nil {
-		return err
-	}
-
-	gardenKey := careInstruction.Namespace + "/" + careInstruction.Name
-	r.gardensMu.RLock()
-	garden, exists := r.gardens[gardenKey]
-	r.gardensMu.RUnlock()
-	if !exists || garden.gardenClient == nil || garden.careInstructionSpec == nil {
-		// TODO: set a status condition here once trigger failures are reported via ShootsReconciled condition
-		return errors.New("garden client not ready, cannot process Cluster reconcile annotations")
-	}
-	gardenClient := *garden.gardenClient
-	gardenNamespace := garden.careInstructionSpec.GardenNamespace
-
-	for i := range clusters.Items {
-		cluster := &clusters.Items[i]
-		if _, hasAnnotation := cluster.Annotations[v1alpha1.ReconcileAnnotation]; !hasAnnotation {
-			continue
-		}
-
-		if err := shoot.AnnotateShootForReconcile(ctx, gardenClient, gardenNamespace, cluster.Name); err != nil {
-			r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", cluster.Name)
-			continue
-		}
-		r.Info("Annotated Shoot for reconciliation via Cluster annotation", "shoot", cluster.Name)
-
-		base := cluster.DeepCopy()
-		delete(cluster.Annotations, v1alpha1.ReconcileAnnotation)
-		if err := r.Patch(ctx, cluster, client.MergeFrom(base)); err != nil {
-			r.Error(err, "failed to remove reconcile annotation from Cluster", "cluster", cluster.Name)
-		}
-	}
 
 	return nil
 }

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -189,6 +189,8 @@ func (r *CareInstructionReconciler) reconcileManager(ctx context.Context, careIn
 			Name:      careInstruction.Spec.AuthenticationConfigMapName,
 		}, &cm); err == nil {
 			initialAuthCMHash = hashAuthConfigMap(&cm)
+		} else if !apierrors.IsNotFound(err) {
+			return err
 		}
 	}
 

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -10,7 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"sort"
 	"sync"
 
 	"shoot-grafter/api/v1alpha1"
@@ -662,17 +661,11 @@ func (r *CareInstructionReconciler) ensureAuthConfigMapLabeled(ctx context.Conte
 	return r.Patch(ctx, &cm, client.MergeFrom(base))
 }
 
-// hashAuthConfigMap returns a SHA-256 hash of the auth ConfigMap's data, used to detect data-only changes.
+// hashAuthConfigMap returns a SHA-256 hash of the config.yaml key in the auth ConfigMap's data.
+// Only config.yaml is hashed so that changes to other keys do not trigger a controller restart.
 func hashAuthConfigMap(cm *corev1.ConfigMap) string {
-	keys := make([]string, 0, len(cm.Data))
-	for k := range cm.Data {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
 	h := sha256.New()
-	for _, k := range keys {
-		fmt.Fprintf(h, "%s=%s\n", k, cm.Data[k])
-	}
+	fmt.Fprint(h, cm.Data["config.yaml"])
 	return hex.EncodeToString(h.Sum(nil))
 }
 

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -469,6 +469,7 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 		existingClusterNames[cluster.Name] = true
 	}
 
+	var retErr error
 	for i := range clusters.Items {
 		cluster := &clusters.Items[i]
 		shootStatus := v1alpha1.ShootStatus{
@@ -493,15 +494,20 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 			gardenNamespace := garden.careInstructionSpec.GardenNamespace
 			if err := shoot.AnnotateShootForReconcile(ctx, *gardenClient, gardenNamespace, cluster.Name); err != nil {
 				r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", cluster.Name)
+				retErr = err
 			} else {
 				r.Info("Annotated Shoot for reconciliation via Cluster annotation", "shoot", cluster.Name)
 				base := cluster.DeepCopy()
 				delete(cluster.Annotations, v1alpha1.ReconcileAnnotation)
 				if err := r.Patch(ctx, cluster, client.MergeFrom(base)); err != nil {
 					r.Error(err, "failed to remove reconcile annotation from Cluster", "cluster", cluster.Name)
+					retErr = err
 				}
 			}
 		}
+	}
+	if retErr != nil {
+		return retErr
 	}
 
 	effectiveShootCount := len(includedShoots)

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -567,14 +567,16 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 // reconcileManager recreates it on the next reconcile, re-applying all shoot-grafter config.
 func (r *CareInstructionReconciler) restartShootController(careInstruction *v1alpha1.CareInstruction) {
 	gardenKey := careInstruction.Namespace + "/" + careInstruction.Name
-	r.gardensMu.RLock()
+	r.gardensMu.Lock()
 	garden, exists := r.gardens[gardenKey]
-	r.gardensMu.RUnlock()
 	if !exists || garden.cancelFunc == nil {
+		r.gardensMu.Unlock()
 		return
 	}
 	r.Info("Restarting shoot controller", "careInstruction", careInstruction.Name)
 	garden.cancelFunc()
+	garden.mgr = nil
+	r.gardensMu.Unlock()
 }
 
 // cleanupCareInstruction - deletes the CareInstruction and cleans up any resources associated with it.

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -46,12 +46,13 @@ type CareInstructionReconciler struct {
 }
 
 type garden struct {
-	mgr                 ctrl.Manager                  // The manager for the garden cluster
-	gardenConfig        *rest.Config                  // The REST config for the garden cluster
-	gardenClient        *client.Client                // The client for the garden cluster
-	careInstructionSpec *v1alpha1.CareInstructionSpec // The CareInstruction object for the garden cluster
-	cancelFunc          context.CancelFunc            // Cancel function to stop the manager
-	stopChan            chan bool                     // Channel to know if the manager is stopped
+	mgr                   ctrl.Manager                  // The manager for the garden cluster
+	gardenConfig          *rest.Config                  // The REST config for the garden cluster
+	gardenClient          *client.Client                // The client for the garden cluster
+	careInstructionSpec   *v1alpha1.CareInstructionSpec // The CareInstruction object for the garden cluster
+	cancelFunc            context.CancelFunc            // Cancel function to stop the manager
+	stopChan              chan bool                     // Channel to know if the manager is stopped
+	authConfigMapRevision string                        // ResourceVersion of the last-seen auth ConfigMap
 }
 
 type careInstructionContextKey struct{}
@@ -133,6 +134,10 @@ func (r *CareInstructionReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 			),
 		)
 		return ctrl.Result{}, err
+	}
+
+	if err := r.reconcileAuthConfigMapChange(ctx, &careInstruction); err != nil {
+		r.Error(err, "failed to reconcile auth ConfigMap change")
 	}
 
 	// reconcile Shoots and Clusters created by this CareInstruction
@@ -549,6 +554,64 @@ func (r *CareInstructionReconciler) reconcileClusterReconcileAnnotations(ctx con
 			r.Error(err, "failed to remove reconcile annotation from Cluster", "cluster", cluster.Name)
 		}
 	}
+
+	return nil
+}
+
+// reconcileAuthConfigMapChange detects when the auth ConfigMap's data has changed since the last
+// reconcile and fans out gardener.cloud/operation=reconcile to all matching Shoots so they pick up
+// the new OIDC configuration.
+func (r *CareInstructionReconciler) reconcileAuthConfigMapChange(ctx context.Context, careInstruction *v1alpha1.CareInstruction) error {
+	if careInstruction.Spec.AuthenticationConfigMapName == "" {
+		return nil
+	}
+
+	gardenKey := careInstruction.Namespace + "/" + careInstruction.Name
+	r.gardensMu.RLock()
+	garden, exists := r.gardens[gardenKey]
+	r.gardensMu.RUnlock()
+	if !exists || garden.gardenClient == nil {
+		return nil
+	}
+
+	var cm corev1.ConfigMap
+	if err := r.Get(ctx, client.ObjectKey{
+		Namespace: careInstruction.Namespace,
+		Name:      careInstruction.Spec.AuthenticationConfigMapName,
+	}, &cm); err != nil {
+		return client.IgnoreNotFound(err)
+	}
+
+	r.gardensMu.RLock()
+	lastRevision := r.gardens[gardenKey].authConfigMapRevision
+	r.gardensMu.RUnlock()
+
+	if cm.ResourceVersion == lastRevision {
+		return nil
+	}
+
+	gardenClient := *garden.gardenClient
+	shoots, err := careInstruction.ListShoots(ctx, gardenClient)
+	if err != nil {
+		return err
+	}
+
+	for i := range shoots.Items {
+		s := &shoots.Items[i]
+		matches, err := careInstruction.MatchesCELFilter(s)
+		if err != nil || !matches {
+			continue
+		}
+		if err := shoot.AnnotateShootForReconcile(ctx, gardenClient, s.Name, s.Namespace); err != nil {
+			r.Error(err, "failed to annotate Shoot for reconciliation after auth ConfigMap change", "shoot", s.Name)
+			continue
+		}
+		r.Info("Annotated Shoot for reconciliation after auth ConfigMap change", "shoot", s.Name)
+	}
+
+	r.gardensMu.Lock()
+	r.gardens[gardenKey].authConfigMapRevision = cm.ResourceVersion
+	r.gardensMu.Unlock()
 
 	return nil
 }

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -443,7 +443,10 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 		}, &cm); err != nil && !apierrors.IsNotFound(err) {
 			return err
 		} else if err == nil {
-			if h := hashAuthConfigMap(&cm); h != garden.authConfigMapHash {
+			r.gardensMu.RLock()
+			prevHash := r.gardens[gardenKey].authConfigMapHash
+			r.gardensMu.RUnlock()
+			if h := hashAuthConfigMap(&cm); h != prevHash {
 				r.gardensMu.Lock()
 				r.gardens[gardenKey].authConfigMapHash = h
 				r.gardensMu.Unlock()

--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -71,7 +71,6 @@ func (r *CareInstructionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&v1alpha1.CareInstruction{}).
 		Watches(&corev1.Secret{}, handler.EnqueueRequestsFromMapFunc(r.enqueueCareInstructionForGardenCluster), builder.WithPredicates(clientutil.PredicateFilterBySecretTypes(greenhouseapis.SecretTypeKubeConfig, greenhouseapis.SecretTypeOIDCConfig))).
 		Watches(&greenhousev1alpha1.Cluster{}, handler.EnqueueRequestsFromMapFunc(r.enqueueCareInstructionForCreatedClusters), builder.WithPredicates(clientutil.PredicateHasLabel(v1alpha1.CareInstructionLabel))).
-		Watches(&greenhousev1alpha1.Cluster{}, handler.EnqueueRequestsFromMapFunc(r.enqueueCareInstructionForClusterReconcileAnnotation), builder.WithPredicates(clientutil.PredicateHasLabel(v1alpha1.CareInstructionLabel), clientutil.PredicateAnnotationAddedOrUpdated(v1alpha1.ReconcileAnnotation))).
 		// Watch auth ConfigMaps; on data change, re-enqueue referencing CareInstructions.
 		Watches(&corev1.ConfigMap{}, handler.EnqueueRequestsFromMapFunc(r.enqueueCareInstructionForAuthConfigMap),
 			builder.WithPredicates(
@@ -783,22 +782,6 @@ func (r *CareInstructionReconciler) enqueueCareInstructionForCreatedClusters(_ c
 			},
 		},
 	}
-}
-
-// enqueueCareInstructionForClusterReconcileAnnotation enqueues the owning CareInstruction when greenhouse.sap/reconcile
-// is added or updated on a Greenhouse Cluster. The actual Shoot annotation is applied in Reconcile.
-func (r *CareInstructionReconciler) enqueueCareInstructionForClusterReconcileAnnotation(_ context.Context, obj client.Object) []ctrl.Request {
-	cluster, ok := obj.(*greenhousev1alpha1.Cluster)
-	if !ok {
-		return nil
-	}
-
-	careInstructionName, exists := cluster.Labels[v1alpha1.CareInstructionLabel]
-	if !exists {
-		return nil
-	}
-
-	return []ctrl.Request{{NamespacedName: client.ObjectKey{Name: careInstructionName, Namespace: cluster.Namespace}}}
 }
 
 // enqueueCareInstructionForAuthConfigMap enqueues all CareInstructions in the same namespace that reference

--- a/controller/careinstruction/careinstruction_controller_test.go
+++ b/controller/careinstruction/careinstruction_controller_test.go
@@ -997,28 +997,9 @@ var _ = Describe("CareInstruction Controller", func() {
 		})
 	})
 
-	Context("When a CareInstruction has the greenhouse.sap/reconcile annotation", func() {
-		It("should annotate all matching Shoots and remove the annotation", func() {
-			By("creating two Shoots on the garden cluster")
-			shoot1 := &gardenerv1beta1.Shoot{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ci-reconcile-shoot-1",
-					Namespace: "default",
-					Labels:    map[string]string{"test": "ci-reconcile"},
-				},
-			}
-			Expect(test.GardenK8sClient.Create(test.Ctx, shoot1)).To(Succeed())
-
-			shoot2 := &gardenerv1beta1.Shoot{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ci-reconcile-shoot-2",
-					Namespace: "default",
-					Labels:    map[string]string{"test": "ci-reconcile"},
-				},
-			}
-			Expect(test.GardenK8sClient.Create(test.Ctx, shoot2)).To(Succeed())
-
-			By("creating a CareInstruction targeting those Shoots")
+	Context("When a CareInstruction has the shoot-grafter.cloudoperators.dev/reconcile annotation", func() {
+		It("should restart the shoot controller and remove the annotation", func() {
+			By("creating a CareInstruction")
 			ci := &v1alpha1.CareInstruction{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-ci-reconcile-annotation",
@@ -1026,11 +1007,6 @@ var _ = Describe("CareInstruction Controller", func() {
 				},
 				Spec: v1alpha1.CareInstructionSpec{
 					GardenClusterName: test.GardenClusterName,
-					ShootSelector: &v1alpha1.ShootSelector{
-						LabelSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"test": "ci-reconcile"},
-						},
-					},
 				},
 			}
 			Expect(test.K8sClient.Create(test.Ctx, ci)).To(Succeed())
@@ -1043,7 +1019,7 @@ var _ = Describe("CareInstruction Controller", func() {
 				g.Expect(cond.IsTrue()).To(BeTrue())
 			}).Should(Succeed())
 
-			By("annotating the CareInstruction with greenhouse.sap/reconcile")
+			By("annotating the CareInstruction with the reconcile annotation")
 			base := ci.DeepCopy()
 			if ci.Annotations == nil {
 				ci.Annotations = make(map[string]string)
@@ -1057,13 +1033,13 @@ var _ = Describe("CareInstruction Controller", func() {
 				g.Expect(ci.Annotations).NotTo(HaveKey(v1alpha1.ReconcileAnnotation))
 			}).Should(Succeed())
 
-			By("verifying gardener.cloud/operation=reconcile is set on each Shoot")
-			for _, shootObj := range []*gardenerv1beta1.Shoot{shoot1, shoot2} {
-				Eventually(func(g Gomega) {
-					g.Expect(test.GardenK8sClient.Get(test.Ctx, client.ObjectKeyFromObject(shootObj), shootObj)).To(Succeed())
-					g.Expect(shootObj.Annotations).To(HaveKeyWithValue("gardener.cloud/operation", "reconcile"))
-				}).Should(Succeed(), "Shoot %s should have gardener.cloud/operation=reconcile", shootObj.Name)
-			}
+			By("verifying the shoot controller restarts")
+			Eventually(func(g Gomega) {
+				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
+				cond := ci.Status.GetConditionByType(v1alpha1.ShootControllerStartedCondition)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.IsTrue()).To(BeTrue())
+			}).Should(Succeed())
 		})
 	})
 
@@ -1410,7 +1386,7 @@ var _ = Describe("CareInstruction Controller", func() {
 	})
 
 	Context("When the auth ConfigMap data changes", func() {
-		It("should annotate all matching Shoots for reconciliation", func() {
+		It("should restart the shoot controller", func() {
 			By("creating an auth ConfigMap")
 			authCM := &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1421,25 +1397,6 @@ var _ = Describe("CareInstruction Controller", func() {
 			}
 			Expect(test.K8sClient.Create(test.Ctx, authCM)).To(Succeed())
 
-			By("creating two Shoots on the garden cluster")
-			shoot1 := &gardenerv1beta1.Shoot{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "auth-cm-shoot-1",
-					Namespace: "default",
-					Labels:    map[string]string{"test": "auth-cm-change"},
-				},
-			}
-			Expect(test.GardenK8sClient.Create(test.Ctx, shoot1)).To(Succeed())
-
-			shoot2 := &gardenerv1beta1.Shoot{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "auth-cm-shoot-2",
-					Namespace: "default",
-					Labels:    map[string]string{"test": "auth-cm-change"},
-				},
-			}
-			Expect(test.GardenK8sClient.Create(test.Ctx, shoot2)).To(Succeed())
-
 			By("creating a CareInstruction with authenticationConfigMapName set")
 			ci := &v1alpha1.CareInstruction{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1449,11 +1406,6 @@ var _ = Describe("CareInstruction Controller", func() {
 				Spec: v1alpha1.CareInstructionSpec{
 					GardenClusterName:           test.GardenClusterName,
 					AuthenticationConfigMapName: authCM.Name,
-					ShootSelector: &v1alpha1.ShootSelector{
-						LabelSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"test": "auth-cm-change"},
-						},
-					},
 				},
 			}
 			Expect(test.K8sClient.Create(test.Ctx, ci)).To(Succeed())
@@ -1466,18 +1418,7 @@ var _ = Describe("CareInstruction Controller", func() {
 				g.Expect(cond.IsTrue()).To(BeTrue())
 			}).Should(Succeed())
 
-			By("waiting for and clearing the initial fan-out triggered by first reconcile")
-			for _, shootObj := range []*gardenerv1beta1.Shoot{shoot1, shoot2} {
-				Eventually(func(g Gomega) {
-					g.Expect(test.GardenK8sClient.Get(test.Ctx, client.ObjectKeyFromObject(shootObj), shootObj)).To(Succeed())
-					g.Expect(shootObj.Annotations).To(HaveKey("gardener.cloud/operation"))
-				}).Should(Succeed())
-				base := shootObj.DeepCopy()
-				delete(shootObj.Annotations, "gardener.cloud/operation")
-				Expect(test.GardenK8sClient.Patch(test.Ctx, shootObj, client.MergeFrom(base))).To(Succeed())
-			}
-
-			By("updating only ConfigMap metadata and verifying no Shoot annotation is set")
+			By("updating only ConfigMap metadata and verifying the shoot controller does not restart")
 			base := authCM.DeepCopy()
 			if authCM.Labels == nil {
 				authCM.Labels = map[string]string{}
@@ -1485,41 +1426,34 @@ var _ = Describe("CareInstruction Controller", func() {
 			authCM.Labels["some-label"] = "some-value"
 			Expect(test.K8sClient.Patch(test.Ctx, authCM, client.MergeFrom(base))).To(Succeed())
 			test.ReconcileObject(ci)
-			for _, shootObj := range []*gardenerv1beta1.Shoot{shoot1, shoot2} {
-				Expect(test.GardenK8sClient.Get(test.Ctx, client.ObjectKeyFromObject(shootObj), shootObj)).To(Succeed())
-				Expect(shootObj.Annotations).NotTo(HaveKey("gardener.cloud/operation"))
-			}
+			Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
+			cond := ci.Status.GetConditionByType(v1alpha1.ShootControllerStartedCondition)
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.IsTrue()).To(BeTrue())
 
-			By("updating the auth ConfigMap data")
+			By("updating the auth ConfigMap data and verifying the shoot controller restarts")
 			base = authCM.DeepCopy()
 			authCM.Data["config.yaml"] = "v2"
 			Expect(test.K8sClient.Patch(test.Ctx, authCM, client.MergeFrom(base))).To(Succeed())
 
-			By("verifying gardener.cloud/operation=reconcile is set on each Shoot")
-			for _, shootObj := range []*gardenerv1beta1.Shoot{shoot1, shoot2} {
-				Eventually(func(g Gomega) {
-					g.Expect(test.GardenK8sClient.Get(test.Ctx, client.ObjectKeyFromObject(shootObj), shootObj)).To(Succeed())
-					g.Expect(shootObj.Annotations).To(HaveKeyWithValue("gardener.cloud/operation", "reconcile"))
-				}).Should(Succeed(), "Shoot %s should have gardener.cloud/operation=reconcile", shootObj.Name)
-			}
+			Eventually(func(g Gomega) {
+				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
+				cond := ci.Status.GetConditionByType(v1alpha1.ShootControllerStartedCondition)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.IsTrue()).To(BeTrue())
+			}).Should(Succeed())
 
-			By("verifying a second CM update also triggers a new fan-out")
-			for _, shootObj := range []*gardenerv1beta1.Shoot{shoot1, shoot2} {
-				base := shootObj.DeepCopy()
-				delete(shootObj.Annotations, "gardener.cloud/operation")
-				Expect(test.GardenK8sClient.Patch(test.Ctx, shootObj, client.MergeFrom(base))).To(Succeed())
-			}
-
+			By("verifying a second CM data update also triggers a restart")
 			base = authCM.DeepCopy()
 			authCM.Data["config.yaml"] = "v3"
 			Expect(test.K8sClient.Patch(test.Ctx, authCM, client.MergeFrom(base))).To(Succeed())
 
-			for _, shootObj := range []*gardenerv1beta1.Shoot{shoot1, shoot2} {
-				Eventually(func(g Gomega) {
-					g.Expect(test.GardenK8sClient.Get(test.Ctx, client.ObjectKeyFromObject(shootObj), shootObj)).To(Succeed())
-					g.Expect(shootObj.Annotations).To(HaveKeyWithValue("gardener.cloud/operation", "reconcile"))
-				}).Should(Succeed(), "Shoot %s should have gardener.cloud/operation=reconcile after second CM update", shootObj.Name)
-			}
+			Eventually(func(g Gomega) {
+				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
+				cond := ci.Status.GetConditionByType(v1alpha1.ShootControllerStartedCondition)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.IsTrue()).To(BeTrue())
+			}).Should(Succeed())
 		})
 	})
 

--- a/controller/careinstruction/careinstruction_controller_test.go
+++ b/controller/careinstruction/careinstruction_controller_test.go
@@ -1036,9 +1036,7 @@ var _ = Describe("CareInstruction Controller", func() {
 			By("verifying the shoot controller restarts")
 			Eventually(func(g Gomega) {
 				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
-				cond := ci.Status.GetConditionByType(v1alpha1.ShootControllerStartedCondition)
-				g.Expect(cond).NotTo(BeNil())
-				g.Expect(cond.IsTrue()).To(BeTrue())
+				g.Expect(ci.Status.ShootControllerRestartCount).To(BeNumerically(">", 0))
 			}).Should(Succeed())
 		})
 	})
@@ -1427,9 +1425,7 @@ var _ = Describe("CareInstruction Controller", func() {
 			Expect(test.K8sClient.Patch(test.Ctx, authCM, client.MergeFrom(base))).To(Succeed())
 			test.ReconcileObject(ci)
 			Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
-			cond := ci.Status.GetConditionByType(v1alpha1.ShootControllerStartedCondition)
-			Expect(cond).NotTo(BeNil())
-			Expect(cond.IsTrue()).To(BeTrue())
+			Expect(ci.Status.ShootControllerRestartCount).To(Equal(0))
 
 			By("updating the auth ConfigMap data and verifying the shoot controller restarts")
 			base = authCM.DeepCopy()
@@ -1438,9 +1434,7 @@ var _ = Describe("CareInstruction Controller", func() {
 
 			Eventually(func(g Gomega) {
 				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
-				cond := ci.Status.GetConditionByType(v1alpha1.ShootControllerStartedCondition)
-				g.Expect(cond).NotTo(BeNil())
-				g.Expect(cond.IsTrue()).To(BeTrue())
+				g.Expect(ci.Status.ShootControllerRestartCount).To(Equal(1))
 			}).Should(Succeed())
 
 			By("verifying a second CM data update also triggers a restart")
@@ -1450,9 +1444,7 @@ var _ = Describe("CareInstruction Controller", func() {
 
 			Eventually(func(g Gomega) {
 				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
-				cond := ci.Status.GetConditionByType(v1alpha1.ShootControllerStartedCondition)
-				g.Expect(cond).NotTo(BeNil())
-				g.Expect(cond.IsTrue()).To(BeTrue())
+				g.Expect(ci.Status.ShootControllerRestartCount).To(Equal(2))
 			}).Should(Succeed())
 		})
 	})

--- a/controller/careinstruction/careinstruction_controller_test.go
+++ b/controller/careinstruction/careinstruction_controller_test.go
@@ -1417,6 +1417,7 @@ var _ = Describe("CareInstruction Controller", func() {
 			}).Should(Succeed())
 
 			By("updating only ConfigMap metadata and verifying the shoot controller does not restart")
+			Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(authCM), authCM)).To(Succeed())
 			base := authCM.DeepCopy()
 			if authCM.Labels == nil {
 				authCM.Labels = map[string]string{}

--- a/controller/careinstruction/careinstruction_controller_test.go
+++ b/controller/careinstruction/careinstruction_controller_test.go
@@ -1430,6 +1430,17 @@ var _ = Describe("CareInstruction Controller", func() {
 				g.Expect(ci.Status.ShootControllerRestartCount).To(Equal(0))
 			}).Should(Succeed())
 
+			By("adding an extra data key and verifying the shoot controller does not restart")
+			Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(authCM), authCM)).To(Succeed())
+			base = authCM.DeepCopy()
+			authCM.Data["unrelated-key"] = "some-value"
+			Expect(test.K8sClient.Patch(test.Ctx, authCM, client.MergeFrom(base))).To(Succeed())
+			test.ReconcileObject(ci)
+			Consistently(func(g Gomega) {
+				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
+				g.Expect(ci.Status.ShootControllerRestartCount).To(Equal(0))
+			}).Should(Succeed())
+
 			By("updating the auth ConfigMap data and verifying the shoot controller restarts")
 			base = authCM.DeepCopy()
 			authCM.Data["config.yaml"] = "v2"

--- a/controller/careinstruction/careinstruction_controller_test.go
+++ b/controller/careinstruction/careinstruction_controller_test.go
@@ -1043,7 +1043,7 @@ var _ = Describe("CareInstruction Controller", func() {
 		})
 	})
 
-	Context("When a Greenhouse Cluster has the greenhouse.sap/reconcile annotation", func() {
+	Context("When a Greenhouse Cluster has the shoot-grafter.cloudoperators.dev/reconcile annotation", func() {
 		It("should annotate the matching Shoot and remove the annotation from the Cluster", func() {
 			By("creating a Shoot on the garden cluster")
 			shoot := &gardenerv1beta1.Shoot{
@@ -1096,7 +1096,7 @@ var _ = Describe("CareInstruction Controller", func() {
 			}
 			Expect(test.K8sClient.Create(test.Ctx, cluster)).To(Succeed())
 
-			By("annotating the Cluster with greenhouse.sap/reconcile")
+			By("annotating the Cluster with shoot-grafter.cloudoperators.dev/reconcile")
 			base := cluster.DeepCopy()
 			cluster.Annotations = map[string]string{v1alpha1.ReconcileAnnotation: "true"}
 			Expect(test.K8sClient.Patch(test.Ctx, cluster, client.MergeFrom(base))).To(Succeed())

--- a/controller/careinstruction/careinstruction_controller_test.go
+++ b/controller/careinstruction/careinstruction_controller_test.go
@@ -997,6 +997,76 @@ var _ = Describe("CareInstruction Controller", func() {
 		})
 	})
 
+	Context("When a CareInstruction has the greenhouse.sap/reconcile annotation", func() {
+		It("should annotate all matching Shoots and remove the annotation", func() {
+			By("creating two Shoots on the garden cluster")
+			shoot1 := &gardenerv1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ci-reconcile-shoot-1",
+					Namespace: "default",
+					Labels:    map[string]string{"test": "ci-reconcile"},
+				},
+			}
+			Expect(test.GardenK8sClient.Create(test.Ctx, shoot1)).To(Succeed())
+
+			shoot2 := &gardenerv1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ci-reconcile-shoot-2",
+					Namespace: "default",
+					Labels:    map[string]string{"test": "ci-reconcile"},
+				},
+			}
+			Expect(test.GardenK8sClient.Create(test.Ctx, shoot2)).To(Succeed())
+
+			By("creating a CareInstruction targeting those Shoots")
+			ci := &v1alpha1.CareInstruction{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ci-reconcile-annotation",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.CareInstructionSpec{
+					GardenClusterName: test.GardenClusterName,
+					ShootSelector: &v1alpha1.ShootSelector{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"test": "ci-reconcile"},
+						},
+					},
+				},
+			}
+			Expect(test.K8sClient.Create(test.Ctx, ci)).To(Succeed())
+
+			By("waiting for the Shoot controller to start")
+			Eventually(func(g Gomega) {
+				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
+				cond := ci.Status.GetConditionByType(v1alpha1.ShootControllerStartedCondition)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.IsTrue()).To(BeTrue())
+			}).Should(Succeed())
+
+			By("annotating the CareInstruction with greenhouse.sap/reconcile")
+			base := ci.DeepCopy()
+			if ci.Annotations == nil {
+				ci.Annotations = make(map[string]string)
+			}
+			ci.Annotations[v1alpha1.ReconcileAnnotation] = "true"
+			Expect(test.K8sClient.Patch(test.Ctx, ci, client.MergeFrom(base))).To(Succeed())
+
+			By("verifying the annotation is removed from the CareInstruction")
+			Eventually(func(g Gomega) {
+				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
+				g.Expect(ci.Annotations).NotTo(HaveKey(v1alpha1.ReconcileAnnotation))
+			}).Should(Succeed())
+
+			By("verifying gardener.cloud/operation=reconcile is set on each Shoot")
+			for _, shootObj := range []*gardenerv1beta1.Shoot{shoot1, shoot2} {
+				Eventually(func(g Gomega) {
+					g.Expect(test.GardenK8sClient.Get(test.Ctx, client.ObjectKeyFromObject(shootObj), shootObj)).To(Succeed())
+					g.Expect(shootObj.Annotations).To(HaveKeyWithValue("gardener.cloud/operation", "reconcile"))
+				}).Should(Succeed(), "Shoot %s should have gardener.cloud/operation=reconcile", shootObj.Name)
+			}
+		})
+	})
+
 	Context("When a CareInstruction is deleted", func() {
 		It("should stop the Shoot controller", func() {
 			shoot := &gardenerv1beta1.Shoot{

--- a/controller/careinstruction/careinstruction_controller_test.go
+++ b/controller/careinstruction/careinstruction_controller_test.go
@@ -1337,4 +1337,94 @@ var _ = Describe("CareInstruction Controller", func() {
 		})
 	})
 
+	Context("When the auth ConfigMap data changes", func() {
+		It("should annotate all matching Shoots for reconciliation", func() {
+			By("creating an auth ConfigMap")
+			authCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "auth-cm-change-test",
+					Namespace: "default",
+				},
+				Data: map[string]string{"config": "v1"},
+			}
+			Expect(test.K8sClient.Create(test.Ctx, authCM)).To(Succeed())
+
+			By("creating two Shoots on the garden cluster")
+			shoot1 := &gardenerv1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "auth-cm-shoot-1",
+					Namespace: "default",
+					Labels:    map[string]string{"test": "auth-cm-change"},
+				},
+			}
+			Expect(test.GardenK8sClient.Create(test.Ctx, shoot1)).To(Succeed())
+
+			shoot2 := &gardenerv1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "auth-cm-shoot-2",
+					Namespace: "default",
+					Labels:    map[string]string{"test": "auth-cm-change"},
+				},
+			}
+			Expect(test.GardenK8sClient.Create(test.Ctx, shoot2)).To(Succeed())
+
+			By("creating a CareInstruction with authenticationConfigMapName set")
+			ci := &v1alpha1.CareInstruction{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ci-auth-cm-change",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.CareInstructionSpec{
+					GardenClusterName:           test.GardenClusterName,
+					AuthenticationConfigMapName: authCM.Name,
+					ShootSelector: &v1alpha1.ShootSelector{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"test": "auth-cm-change"},
+						},
+					},
+				},
+			}
+			Expect(test.K8sClient.Create(test.Ctx, ci)).To(Succeed())
+
+			By("waiting for the Shoot controller to start")
+			Eventually(func(g Gomega) {
+				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
+				cond := ci.Status.GetConditionByType(v1alpha1.ShootControllerStartedCondition)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.IsTrue()).To(BeTrue())
+			}).Should(Succeed())
+
+			By("updating the auth ConfigMap data")
+			base := authCM.DeepCopy()
+			authCM.Data["config"] = "v2"
+			Expect(test.K8sClient.Patch(test.Ctx, authCM, client.MergeFrom(base))).To(Succeed())
+
+			By("verifying gardener.cloud/operation=reconcile is set on each Shoot")
+			for _, shootObj := range []*gardenerv1beta1.Shoot{shoot1, shoot2} {
+				Eventually(func(g Gomega) {
+					g.Expect(test.GardenK8sClient.Get(test.Ctx, client.ObjectKeyFromObject(shootObj), shootObj)).To(Succeed())
+					g.Expect(shootObj.Annotations).To(HaveKeyWithValue("gardener.cloud/operation", "reconcile"))
+				}).Should(Succeed(), "Shoot %s should have gardener.cloud/operation=reconcile", shootObj.Name)
+			}
+
+			By("verifying a second CM update also triggers a new fan-out")
+			for _, shootObj := range []*gardenerv1beta1.Shoot{shoot1, shoot2} {
+				base := shootObj.DeepCopy()
+				delete(shootObj.Annotations, "gardener.cloud/operation")
+				Expect(test.GardenK8sClient.Patch(test.Ctx, shootObj, client.MergeFrom(base))).To(Succeed())
+			}
+
+			base = authCM.DeepCopy()
+			authCM.Data["config"] = "v3"
+			Expect(test.K8sClient.Patch(test.Ctx, authCM, client.MergeFrom(base))).To(Succeed())
+
+			for _, shootObj := range []*gardenerv1beta1.Shoot{shoot1, shoot2} {
+				Eventually(func(g Gomega) {
+					g.Expect(test.GardenK8sClient.Get(test.Ctx, client.ObjectKeyFromObject(shootObj), shootObj)).To(Succeed())
+					g.Expect(shootObj.Annotations).To(HaveKeyWithValue("gardener.cloud/operation", "reconcile"))
+				}).Should(Succeed(), "Shoot %s should have gardener.cloud/operation=reconcile after second CM update", shootObj.Name)
+			}
+		})
+	})
+
 })

--- a/controller/careinstruction/careinstruction_controller_test.go
+++ b/controller/careinstruction/careinstruction_controller_test.go
@@ -1424,8 +1424,10 @@ var _ = Describe("CareInstruction Controller", func() {
 			authCM.Labels["some-label"] = "some-value"
 			Expect(test.K8sClient.Patch(test.Ctx, authCM, client.MergeFrom(base))).To(Succeed())
 			test.ReconcileObject(ci)
-			Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
-			Expect(ci.Status.ShootControllerRestartCount).To(Equal(0))
+			Consistently(func(g Gomega) {
+				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
+				g.Expect(ci.Status.ShootControllerRestartCount).To(Equal(0))
+			}).Should(Succeed())
 
 			By("updating the auth ConfigMap data and verifying the shoot controller restarts")
 			base = authCM.DeepCopy()

--- a/controller/careinstruction/careinstruction_controller_test.go
+++ b/controller/careinstruction/careinstruction_controller_test.go
@@ -1067,6 +1067,78 @@ var _ = Describe("CareInstruction Controller", func() {
 		})
 	})
 
+	Context("When a Greenhouse Cluster has the greenhouse.sap/reconcile annotation", func() {
+		It("should annotate the matching Shoot and remove the annotation from the Cluster", func() {
+			By("creating a Shoot on the garden cluster")
+			shoot := &gardenerv1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cluster-reconcile-shoot",
+					Namespace: "default",
+					Labels:    map[string]string{"test": "cluster-reconcile"},
+				},
+			}
+			Expect(test.GardenK8sClient.Create(test.Ctx, shoot)).To(Succeed())
+
+			By("creating a CareInstruction targeting the Shoot")
+			ci := &v1alpha1.CareInstruction{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-ci-cluster-reconcile",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.CareInstructionSpec{
+					GardenClusterName: test.GardenClusterName,
+					GardenNamespace:   "default",
+					ShootSelector: &v1alpha1.ShootSelector{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"test": "cluster-reconcile"},
+						},
+					},
+				},
+			}
+			Expect(test.K8sClient.Create(test.Ctx, ci)).To(Succeed())
+
+			By("waiting for the Shoot controller to start")
+			Eventually(func(g Gomega) {
+				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(ci), ci)).To(Succeed())
+				cond := ci.Status.GetConditionByType(v1alpha1.ShootControllerStartedCondition)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.IsTrue()).To(BeTrue())
+			}).Should(Succeed())
+
+			By("creating a Greenhouse Cluster owned by the CareInstruction")
+			cluster := &greenhousev1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      shoot.Name,
+					Namespace: "default",
+					Labels: map[string]string{
+						v1alpha1.CareInstructionLabel: ci.Name,
+					},
+				},
+				Spec: greenhousev1alpha1.ClusterSpec{
+					AccessMode: greenhousev1alpha1.ClusterAccessModeDirect,
+				},
+			}
+			Expect(test.K8sClient.Create(test.Ctx, cluster)).To(Succeed())
+
+			By("annotating the Cluster with greenhouse.sap/reconcile")
+			base := cluster.DeepCopy()
+			cluster.Annotations = map[string]string{v1alpha1.ReconcileAnnotation: "true"}
+			Expect(test.K8sClient.Patch(test.Ctx, cluster, client.MergeFrom(base))).To(Succeed())
+
+			By("verifying gardener.cloud/operation=reconcile is set on the Shoot")
+			Eventually(func(g Gomega) {
+				g.Expect(test.GardenK8sClient.Get(test.Ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+				g.Expect(shoot.Annotations).To(HaveKeyWithValue("gardener.cloud/operation", "reconcile"))
+			}).Should(Succeed())
+
+			By("verifying the annotation is removed from the Cluster")
+			Eventually(func(g Gomega) {
+				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(cluster), cluster)).To(Succeed())
+				g.Expect(cluster.Annotations).NotTo(HaveKey(v1alpha1.ReconcileAnnotation))
+			}).Should(Succeed())
+		})
+	})
+
 	Context("When a CareInstruction is deleted", func() {
 		It("should stop the Shoot controller", func() {
 			shoot := &gardenerv1beta1.Shoot{
@@ -1345,7 +1417,7 @@ var _ = Describe("CareInstruction Controller", func() {
 					Name:      "auth-cm-change-test",
 					Namespace: "default",
 				},
-				Data: map[string]string{"config": "v1"},
+				Data: map[string]string{"config.yaml": "v1"},
 			}
 			Expect(test.K8sClient.Create(test.Ctx, authCM)).To(Succeed())
 
@@ -1394,9 +1466,33 @@ var _ = Describe("CareInstruction Controller", func() {
 				g.Expect(cond.IsTrue()).To(BeTrue())
 			}).Should(Succeed())
 
-			By("updating the auth ConfigMap data")
+			By("waiting for and clearing the initial fan-out triggered by first reconcile")
+			for _, shootObj := range []*gardenerv1beta1.Shoot{shoot1, shoot2} {
+				Eventually(func(g Gomega) {
+					g.Expect(test.GardenK8sClient.Get(test.Ctx, client.ObjectKeyFromObject(shootObj), shootObj)).To(Succeed())
+					g.Expect(shootObj.Annotations).To(HaveKey("gardener.cloud/operation"))
+				}).Should(Succeed())
+				base := shootObj.DeepCopy()
+				delete(shootObj.Annotations, "gardener.cloud/operation")
+				Expect(test.GardenK8sClient.Patch(test.Ctx, shootObj, client.MergeFrom(base))).To(Succeed())
+			}
+
+			By("updating only ConfigMap metadata and verifying no Shoot annotation is set")
 			base := authCM.DeepCopy()
-			authCM.Data["config"] = "v2"
+			if authCM.Labels == nil {
+				authCM.Labels = map[string]string{}
+			}
+			authCM.Labels["some-label"] = "some-value"
+			Expect(test.K8sClient.Patch(test.Ctx, authCM, client.MergeFrom(base))).To(Succeed())
+			test.ReconcileObject(ci)
+			for _, shootObj := range []*gardenerv1beta1.Shoot{shoot1, shoot2} {
+				Expect(test.GardenK8sClient.Get(test.Ctx, client.ObjectKeyFromObject(shootObj), shootObj)).To(Succeed())
+				Expect(shootObj.Annotations).NotTo(HaveKey("gardener.cloud/operation"))
+			}
+
+			By("updating the auth ConfigMap data")
+			base = authCM.DeepCopy()
+			authCM.Data["config.yaml"] = "v2"
 			Expect(test.K8sClient.Patch(test.Ctx, authCM, client.MergeFrom(base))).To(Succeed())
 
 			By("verifying gardener.cloud/operation=reconcile is set on each Shoot")
@@ -1415,7 +1511,7 @@ var _ = Describe("CareInstruction Controller", func() {
 			}
 
 			base = authCM.DeepCopy()
-			authCM.Data["config"] = "v3"
+			authCM.Data["config.yaml"] = "v3"
 			Expect(test.K8sClient.Patch(test.Ctx, authCM, client.MergeFrom(base))).To(Succeed())
 
 			for _, shootObj := range []*gardenerv1beta1.Shoot{shoot1, shoot2} {

--- a/controller/shoot/auth.go
+++ b/controller/shoot/auth.go
@@ -145,7 +145,7 @@ func (r *ShootController) configureOIDCAuthentication(ctx context.Context, shoot
 	// Trigger Shoot reconciliation if ConfigMap content was updated
 	// Reference: https://gardener.cloud/docs/gardener/shoot-operations/shoot_operations/#immediate-reconciliation
 	if configMapResult == controllerutil.OperationResultUpdated {
-		if err := AnnotateShootForReconcile(ctx, r.GardenClient, shoot.Name, shoot.Namespace); err != nil {
+		if err := AnnotateShootForReconcile(ctx, r.GardenClient, shoot.Namespace, shoot.Name); err != nil {
 			return fmt.Errorf("failed to annotate Shoot for reconciliation: %w", err)
 		}
 		r.Info("Annotated Shoot for reconciliation due to ConfigMap content update",

--- a/controller/shoot/auth.go
+++ b/controller/shoot/auth.go
@@ -145,12 +145,7 @@ func (r *ShootController) configureOIDCAuthentication(ctx context.Context, shoot
 	// Trigger Shoot reconciliation if ConfigMap content was updated
 	// Reference: https://gardener.cloud/docs/gardener/shoot-operations/shoot_operations/#immediate-reconciliation
 	if configMapResult == controllerutil.OperationResultUpdated {
-		if shoot.Annotations == nil {
-			shoot.Annotations = make(map[string]string)
-		}
-		shoot.Annotations["gardener.cloud/operation"] = "reconcile"
-
-		if err := r.GardenClient.Update(ctx, shoot); err != nil {
+		if err := AnnotateShootForReconcile(ctx, r.GardenClient, shoot.Name, shoot.Namespace); err != nil {
 			return fmt.Errorf("failed to annotate Shoot for reconciliation: %w", err)
 		}
 		r.Info("Annotated Shoot for reconciliation due to ConfigMap content update",

--- a/controller/shoot/shoot_controller.go
+++ b/controller/shoot/shoot_controller.go
@@ -358,7 +358,7 @@ func GenerateName(gardenClusterName string) string {
 }
 
 // AnnotateShootForReconcile sets gardener.cloud/operation: reconcile on the named Shoot.
-func AnnotateShootForReconcile(ctx context.Context, gardenClient client.Client, name, namespace string) error {
+func AnnotateShootForReconcile(ctx context.Context, gardenClient client.Client, namespace, name string) error {
 	var s gardenerv1beta1.Shoot
 	if err := gardenClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &s); err != nil {
 		return fmt.Errorf("failed to get Shoot %s/%s: %w", namespace, name, err)

--- a/controller/shoot/shoot_controller.go
+++ b/controller/shoot/shoot_controller.go
@@ -356,3 +356,17 @@ func (r *ShootController) RequestClusterDeletion(ctx context.Context, existingCl
 func GenerateName(gardenClusterName string) string {
 	return "shoot-controller-" + gardenClusterName
 }
+
+// AnnotateShootForReconcile sets gardener.cloud/operation: reconcile on the named Shoot.
+func AnnotateShootForReconcile(ctx context.Context, gardenClient client.Client, name, namespace string) error {
+	var s gardenerv1beta1.Shoot
+	if err := gardenClient.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, &s); err != nil {
+		return fmt.Errorf("failed to get Shoot %s/%s: %w", namespace, name, err)
+	}
+	base := s.DeepCopy()
+	if s.Annotations == nil {
+		s.Annotations = make(map[string]string)
+	}
+	s.Annotations["gardener.cloud/operation"] = "reconcile"
+	return gardenClient.Patch(ctx, &s, client.MergeFrom(base))
+}

--- a/crd/shoot-grafter.cloudoperators.dev_careinstructions.yaml
+++ b/crd/shoot-grafter.cloudoperators.dev_careinstructions.yaml
@@ -184,6 +184,10 @@ spec:
                 description: FailedClusters is the number of clusters that failed
                   to be created by this CareInstruction.
                 type: integer
+              shootControllerRestartCount:
+                description: ShootControllerRestartCount is the number of times the
+                  shoot controller has been restarted.
+                type: integer
               shoots:
                 description: Shoots is a list of shoots targeted by this CareInstruction
                   with their detailed status.

--- a/internal/clientutil/predicates.go
+++ b/internal/clientutil/predicates.go
@@ -31,6 +31,22 @@ func PredicateHasLabel(key string) predicate.Predicate {
 	})
 }
 
+// PredicateAnnotationAddedOrUpdated fires on Create and on Update when the given annotation is present and its value has changed.
+func PredicateAnnotationAddedOrUpdated(key string) predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			_, exists := e.Object.GetAnnotations()[key]
+			return exists
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldVal, oldExists := e.ObjectOld.GetAnnotations()[key]
+			newVal, newExists := e.ObjectNew.GetAnnotations()[key]
+			return newExists && (!oldExists || oldVal != newVal)
+		},
+		DeleteFunc: func(_ event.DeleteEvent) bool { return false },
+	}
+}
+
 // PredicateConfigMapDataChanged fires on Create and on Update only when the ConfigMap Data changes.
 func PredicateConfigMapDataChanged() predicate.Predicate {
 	return predicate.Funcs{

--- a/internal/clientutil/predicates.go
+++ b/internal/clientutil/predicates.go
@@ -31,22 +31,6 @@ func PredicateHasLabel(key string) predicate.Predicate {
 	})
 }
 
-// PredicateAnnotationAddedOrUpdated fires on Create and on Update when the given annotation is present and its value has changed.
-func PredicateAnnotationAddedOrUpdated(key string) predicate.Predicate {
-	return predicate.Funcs{
-		CreateFunc: func(e event.CreateEvent) bool {
-			_, exists := e.Object.GetAnnotations()[key]
-			return exists
-		},
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			oldVal, oldExists := e.ObjectOld.GetAnnotations()[key]
-			newVal, newExists := e.ObjectNew.GetAnnotations()[key]
-			return newExists && (!oldExists || oldVal != newVal)
-		},
-		DeleteFunc: func(_ event.DeleteEvent) bool { return false },
-	}
-}
-
 // PredicateConfigMapDataChanged fires on Create and on Update only when the ConfigMap Data changes.
 func PredicateConfigMapDataChanged() predicate.Predicate {
 	return predicate.Funcs{


### PR DESCRIPTION
## Summary

- Annotating a Greenhouse Cluster with `shoot-grafter.cloudoperators.dev/reconcile: "true"` sets `gardener.cloud/operation: reconcile` on the matching Shoot and removes the annotation.
- Annotating a CareInstruction with `shoot-grafter.cloudoperators.dev/reconcile: "true"` restarts the shoot controller for that CareInstruction and removes the annotation.
- Auth ConfigMap data changes now restart the shoot controller, ensuring shoot-grafter re-applies its own config to all matching Shoots (leftover from #41).

## Notes

- The `shoot-grafter.cloudoperators.dev/reconcile` annotation is owned by shoot-grafter (not Greenhouse) to avoid conflicts with Greenhouse controllers.
- The Cluster annotation trigger uses `gardener.cloud/operation: reconcile` because it targets Gardener's own reconciliation. The CI and auth CM triggers restart the shoot controller instead, since they need shoot-grafter to re-apply its own config - not just Gardener's.
- The annotation is consumed (removed) after processing.
- All three trigger paths are handled inline in reconcileShootsNClusters to avoid duplicate list calls.