### PR TITLE
fix(careinstruction): report each shoot once in status.shoots

### DIFF
--- a/controller/careinstruction/careinstruction_controller.go
+++ b/controller/careinstruction/careinstruction_controller.go
@@ -413,23 +413,16 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 	}
 
 	var includedShoots []gardenerv1beta1.Shoot
+	excludedShoots := make(map[string]string)
 	for _, shoot := range shoots.Items {
 		matches, err := careInstruction.MatchesCELFilter(&shoot)
 		switch {
 		case err != nil:
 			r.Info("CEL evaluation failed", "shoot", shoot.Name, "error", err.Error())
-			careInstruction.Status.Shoots = append(careInstruction.Status.Shoots, v1alpha1.ShootStatus{
-				Name:    shoot.Name,
-				Status:  v1alpha1.ShootStatusExcluded,
-				Message: "CEL evaluation failed: " + err.Error(),
-			})
+			excludedShoots[shoot.Name] = "CEL evaluation failed: " + err.Error()
 		case !matches:
 			r.Info("Shoot filtered out by CEL expression", "shoot", shoot.Name)
-			careInstruction.Status.Shoots = append(careInstruction.Status.Shoots, v1alpha1.ShootStatus{
-				Name:    shoot.Name,
-				Status:  v1alpha1.ShootStatusExcluded,
-				Message: "filtered out by CEL expression",
-			})
+			excludedShoots[shoot.Name] = "filtered out by CEL expression"
 		default:
 			includedShoots = append(includedShoots, shoot)
 		}
@@ -473,52 +466,42 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 		existingClusterNames[cluster.Name] = true
 	}
 
+	matchedOwnedCount := 0
+	for _, shoot := range includedShoots {
+		if existingClusterNames[shoot.Name] {
+			matchedOwnedCount++
+		}
+	}
+
+	// Handle Cluster reconcile annotation: annotate the matching Shoot and remove the annotation.
 	var retErr error
 	for i := range clusters.Items {
 		cluster := &clusters.Items[i]
-		shootStatus := v1alpha1.ShootStatus{
-			Name: cluster.Name,
+		if cluster.Annotations[v1alpha1.ReconcileAnnotation] != "true" {
+			continue
 		}
-
-		if cluster.Status.IsReadyTrue() {
-			shootStatus.Status = v1alpha1.ShootStatusOnboarded
-		} else {
-			shootStatus.Status = v1alpha1.ShootStatusFailed
-			readyCondition := cluster.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
-			if readyCondition != nil && readyCondition.Message != "" {
-				shootStatus.Message = readyCondition.Message
-			}
-			careInstruction.Status.FailedClusters++
+		gardenNamespace := careInstruction.Spec.GardenNamespace
+		if err := shoot.AnnotateShootForReconcile(ctx, *gardenClient, gardenNamespace, cluster.Name); err != nil {
+			r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", cluster.Name)
+			retErr = err
+			continue
 		}
-
-		careInstruction.Status.Shoots = append(careInstruction.Status.Shoots, shootStatus)
-
-		// Handle Cluster reconcile annotation: annotate the matching Shoot and remove the annotation.
-		if cluster.Annotations[v1alpha1.ReconcileAnnotation] == "true" {
-			gardenNamespace := careInstruction.Spec.GardenNamespace
-			if err := shoot.AnnotateShootForReconcile(ctx, *gardenClient, gardenNamespace, cluster.Name); err != nil {
-				r.Error(err, "failed to annotate Shoot for reconciliation", "shoot", cluster.Name)
-				retErr = err
-			} else {
-				r.Info("Annotated Shoot for reconciliation via Cluster annotation", "shoot", cluster.Name)
-				base := cluster.DeepCopy()
-				delete(cluster.Annotations, v1alpha1.ReconcileAnnotation)
-				if err := r.Patch(ctx, cluster, client.MergeFrom(base)); err != nil {
-					r.Error(err, "failed to remove reconcile annotation from Cluster", "cluster", cluster.Name)
-					retErr = err
-				}
-			}
+		r.Info("Annotated Shoot for reconciliation via Cluster annotation", "shoot", cluster.Name)
+		base := cluster.DeepCopy()
+		delete(cluster.Annotations, v1alpha1.ReconcileAnnotation)
+		if err := r.Patch(ctx, cluster, client.MergeFrom(base)); err != nil {
+			r.Error(err, "failed to remove reconcile annotation from Cluster", "cluster", cluster.Name)
+			retErr = err
 		}
 	}
-	if retErr != nil {
-		return retErr
-	}
 
-	effectiveShootCount := len(includedShoots)
-	if effectiveShootCount != careInstruction.Status.CreatedClusters {
+	var conflicts map[string]conflictInfo
+	countsMatch := len(includedShoots) == matchedOwnedCount
+	if !countsMatch {
+		conflicts = make(map[string]conflictInfo)
 		r.Info("Shoot count does not match cluster count, checking for ownership conflicts",
-			"effectiveShoots", effectiveShootCount,
-			"createdClusters", careInstruction.Status.CreatedClusters)
+			"effectiveShoots", len(includedShoots),
+			"ownedClusters", matchedOwnedCount)
 
 		// Only check ownership conflicts for shoots that pass all filters.
 		// Filtered-out shoots should not have new clusters created.
@@ -538,26 +521,26 @@ func (r *CareInstructionReconciler) reconcileShootsNClusters(ctx context.Context
 						"managedBy", ownerLabel,
 						"attemptedBy", careInstruction.Name)
 
-					shootStatus := v1alpha1.ShootStatus{
-						Name:    shoot.Name,
-						Message: "Cluster managed by different CareInstruction: " + ownerLabel,
+					conflicts[shoot.Name] = conflictInfo{
+						owner: ownerLabel,
+						ready: existingCluster.Status.IsReadyTrue(),
 					}
-
-					if existingCluster.Status.IsReadyTrue() {
-						shootStatus.Status = v1alpha1.ShootStatusOnboarded
-					} else {
-						shootStatus.Status = v1alpha1.ShootStatusFailed
-						careInstruction.Status.FailedClusters++
-					}
-
-					careInstruction.Status.Shoots = append(careInstruction.Status.Shoots, shootStatus)
 				}
 			} else if !apierrors.IsNotFound(err) {
 				// Some other error occurred
 				return err
 			}
 		}
+	}
 
+	careInstruction.Status.Shoots, careInstruction.Status.FailedClusters = buildShootStatuses(excludedShoots, clusters.Items, conflicts)
+
+	// The status is built first so an annotation failure still reports the current shoots.
+	if retErr != nil {
+		return retErr
+	}
+
+	if !countsMatch {
 		err := errors.New("shoot count and cluster count do not match")
 		return err
 	}

--- a/controller/careinstruction/careinstruction_controller_test.go
+++ b/controller/careinstruction/careinstruction_controller_test.go
@@ -5,6 +5,7 @@ package careinstruction_test
 
 import (
 	"shoot-grafter/api/v1alpha1"
+	"shoot-grafter/controller/careinstruction"
 	"shoot-grafter/internal/test"
 
 	greenhouseapis "github.com/cloudoperators/greenhouse/api"
@@ -12,6 +13,8 @@ import (
 	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	promtest "github.com/prometheus/client_golang/prometheus/testutil"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1380,6 +1383,99 @@ var _ = Describe("CareInstruction Controller", func() {
 				}
 				return true
 			}).Should(BeTrue())
+		})
+
+		It("should report a previously onboarded shoot only once when it stops matching the CEL expression", func() {
+			By("Creating a healthy shoot that matches the CEL expression")
+			shoot := &gardenerv1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "cel-shoot-regressed",
+					Namespace: "default",
+					Labels:    map[string]string{"test": "cel-regression"},
+				},
+			}
+			Expect(test.GardenK8sClient.Create(test.Ctx, shoot)).To(Succeed())
+			shoot.Status = gardenerv1beta1.ShootStatus{
+				LastOperation: &gardenerv1beta1.LastOperation{State: gardenerv1beta1.LastOperationStateSucceeded},
+			}
+			Expect(test.GardenK8sClient.Status().Update(test.Ctx, shoot)).To(Succeed())
+
+			careInstruction := &v1alpha1.CareInstruction{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-cel-regression",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.CareInstructionSpec{
+					GardenClusterName: test.GardenClusterName,
+					ShootSelector: &v1alpha1.ShootSelector{
+						LabelSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"test": "cel-regression"},
+						},
+						Expression: `object.status.lastOperation.state == "Succeeded"`,
+					},
+				},
+			}
+			Expect(test.K8sClient.Create(test.Ctx, careInstruction)).To(Succeed())
+
+			By("Onboarding the shoot by creating an owned, ready cluster")
+			cluster := &greenhousev1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      shoot.Name,
+					Namespace: "default",
+					Labels:    map[string]string{v1alpha1.CareInstructionLabel: careInstruction.Name},
+				},
+				Spec: greenhousev1alpha1.ClusterSpec{AccessMode: greenhousev1alpha1.ClusterAccessModeDirect},
+			}
+			Expect(test.K8sClient.Create(test.Ctx, cluster)).To(Succeed())
+			cluster.Status.SetConditions(greenhousemetav1alpha1.NewCondition(
+				greenhousemetav1alpha1.ReadyCondition, metav1.ConditionTrue, "ClusterReady", "Cluster is ready"))
+			Expect(test.K8sClient.Status().Update(test.Ctx, cluster)).To(Succeed())
+
+			gaugeLabels := prometheus.Labels{
+				"care_instruction": careInstruction.Name,
+				"namespace":        careInstruction.Namespace,
+				"garden_namespace": careInstruction.Spec.GardenNamespace,
+				"shoot_name":       shoot.Name,
+			}
+
+			Eventually(func(g Gomega) bool {
+				defer func() {
+					test.ReconcileObject(careInstruction)
+				}()
+				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(careInstruction), careInstruction)).To(Succeed())
+				g.Expect(careInstruction.Status.Shoots).To(HaveLen(1))
+				g.Expect(careInstruction.Status.Shoots[0].Status).To(Equal(v1alpha1.ShootStatusOnboarded))
+				g.Expect(promtest.ToFloat64(careinstruction.ShootOnboardedGauge.With(gaugeLabels))).To(Equal(1.0))
+				return true
+			}).Should(BeTrue(), "shoot should first be onboarded")
+
+			By("Degrading the shoot so it no longer matches the CEL expression")
+			Expect(test.GardenK8sClient.Get(test.Ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+			shoot.Status.LastOperation = &gardenerv1beta1.LastOperation{State: gardenerv1beta1.LastOperationStateFailed}
+			Expect(test.GardenK8sClient.Status().Update(test.Ctx, shoot)).To(Succeed())
+
+			Eventually(func(g Gomega) bool {
+				defer func() {
+					test.ReconcileObject(careInstruction)
+				}()
+				g.Expect(test.K8sClient.Get(test.Ctx, client.ObjectKeyFromObject(careInstruction), careInstruction)).To(Succeed())
+
+				g.Expect(careInstruction.Status.Shoots).To(HaveLen(1), "the shoot must be listed exactly once")
+				g.Expect(careInstruction.Status.Shoots[0].Name).To(Equal(shoot.Name))
+				g.Expect(careInstruction.Status.Shoots[0].Status).To(Equal(v1alpha1.ShootStatusExcluded))
+				g.Expect(careInstruction.Status.Shoots[0].Message).To(ContainSubstring("filtered out by CEL expression"))
+
+				g.Expect(careInstruction.Status.CreatedClusters).To(Equal(1), "the owned cluster still exists")
+				g.Expect(careInstruction.Status.FailedClusters).To(Equal(0))
+
+				shootsReconciledCondition := careInstruction.Status.GetConditionByType(v1alpha1.ShootsReconciledCondition)
+				g.Expect(shootsReconciledCondition).ToNot(BeNil())
+				g.Expect(shootsReconciledCondition.Status).To(Equal(metav1.ConditionTrue), "an excluded shoot must not block reconciliation")
+
+				g.Expect(promtest.ToFloat64(careinstruction.ShootOnboardedGauge.With(gaugeLabels))).To(Equal(0.0), "the onboarded gauge must follow the deduplicated status")
+
+				return true
+			}).Should(BeTrue(), "excluded shoot should replace the onboarded entry")
 		})
 	})
 

--- a/controller/careinstruction/shootstatus.go
+++ b/controller/careinstruction/shootstatus.go
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package careinstruction
+
+import (
+	"sort"
+
+	greenhousemetav1alpha1 "github.com/cloudoperators/greenhouse/api/meta/v1alpha1"
+	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
+
+	"shoot-grafter/api/v1alpha1"
+)
+
+// conflictInfo describes a shoot whose Greenhouse Cluster is owned by a different CareInstruction.
+type conflictInfo struct {
+	owner string
+	ready bool
+}
+
+// shootStatusRank orders shoot statuses by precedence. The highest rank wins when a shoot is
+// reported by more than one source: Excluded states the shoot is no longer selected at all, and
+// Failed must not be masked by Onboarded.
+func shootStatusRank(status string) int {
+	switch status {
+	case v1alpha1.ShootStatusExcluded:
+		return 2
+	case v1alpha1.ShootStatusFailed:
+		return 1
+	default:
+		return 0
+	}
+}
+
+// buildShootStatuses merges the shoots excluded by the ShootSelector, the Greenhouse Clusters owned
+// by this CareInstruction and the ownership conflicts into a single entry per shoot name, sorted by
+// name. It also returns how many entries ended up as Failed.
+func buildShootStatuses(
+	excluded map[string]string,
+	ownedClusters []greenhousev1alpha1.Cluster,
+	conflicts map[string]conflictInfo,
+) (statuses []v1alpha1.ShootStatus, failed int) {
+
+	byName := make(map[string]v1alpha1.ShootStatus, len(excluded)+len(ownedClusters)+len(conflicts))
+	setStatus := func(shootStatus v1alpha1.ShootStatus) {
+		if current, ok := byName[shootStatus.Name]; ok && shootStatusRank(current.Status) > shootStatusRank(shootStatus.Status) {
+			return
+		}
+		byName[shootStatus.Name] = shootStatus
+	}
+
+	for name, reason := range excluded {
+		setStatus(v1alpha1.ShootStatus{
+			Name:    name,
+			Status:  v1alpha1.ShootStatusExcluded,
+			Message: reason,
+		})
+	}
+
+	for _, cluster := range ownedClusters {
+		shootStatus := v1alpha1.ShootStatus{Name: cluster.Name}
+		if cluster.Status.IsReadyTrue() {
+			shootStatus.Status = v1alpha1.ShootStatusOnboarded
+		} else {
+			shootStatus.Status = v1alpha1.ShootStatusFailed
+			readyCondition := cluster.Status.GetConditionByType(greenhousemetav1alpha1.ReadyCondition)
+			if readyCondition != nil && readyCondition.Message != "" {
+				shootStatus.Message = readyCondition.Message
+			}
+		}
+		setStatus(shootStatus)
+	}
+
+	for name, conflict := range conflicts {
+		shootStatus := v1alpha1.ShootStatus{
+			Name:    name,
+			Message: "Cluster managed by different CareInstruction: " + conflict.owner,
+		}
+		if conflict.ready {
+			shootStatus.Status = v1alpha1.ShootStatusOnboarded
+		} else {
+			shootStatus.Status = v1alpha1.ShootStatusFailed
+		}
+		setStatus(shootStatus)
+	}
+
+	statuses = make([]v1alpha1.ShootStatus, 0, len(byName))
+	for _, shootStatus := range byName {
+		statuses = append(statuses, shootStatus)
+		if shootStatus.Status == v1alpha1.ShootStatusFailed {
+			failed++
+		}
+	}
+	sort.Slice(statuses, func(i, j int) bool { return statuses[i].Name < statuses[j].Name })
+
+	return statuses, failed
+}

--- a/controller/careinstruction/shootstatus_test.go
+++ b/controller/careinstruction/shootstatus_test.go
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package careinstruction
+
+import (
+	greenhousemetav1alpha1 "github.com/cloudoperators/greenhouse/api/meta/v1alpha1"
+	greenhousev1alpha1 "github.com/cloudoperators/greenhouse/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"shoot-grafter/api/v1alpha1"
+)
+
+func readyCluster(name string) greenhousev1alpha1.Cluster {
+	cluster := greenhousev1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	cluster.Status.SetConditions(greenhousemetav1alpha1.NewCondition(
+		greenhousemetav1alpha1.ReadyCondition, metav1.ConditionTrue, "ClusterReady", "Cluster is ready"))
+	return cluster
+}
+
+func notReadyCluster(name, message string) greenhousev1alpha1.Cluster {
+	cluster := greenhousev1alpha1.Cluster{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	cluster.Status.SetConditions(greenhousemetav1alpha1.NewCondition(
+		greenhousemetav1alpha1.ReadyCondition, metav1.ConditionFalse, "ClusterNotReady", message))
+	return cluster
+}
+
+var _ = Describe("buildShootStatuses", func() {
+	It("reports an excluded shoot once, even when it still owns a ready cluster", func() {
+		statuses, failed := buildShootStatuses(
+			map[string]string{"shoot-a": "excluded for test reasons"},
+			[]greenhousev1alpha1.Cluster{readyCluster("shoot-a")},
+			nil,
+		)
+
+		Expect(statuses).To(HaveLen(1))
+		Expect(statuses[0].Name).To(Equal("shoot-a"))
+		Expect(statuses[0].Status).To(Equal(v1alpha1.ShootStatusExcluded))
+		Expect(statuses[0].Message).To(Equal("excluded for test reasons"))
+		Expect(failed).To(Equal(0))
+	})
+
+	It("does not count an excluded shoot as failed when its cluster is not ready", func() {
+		statuses, failed := buildShootStatuses(
+			map[string]string{"shoot-a": "excluded for test reasons"},
+			[]greenhousev1alpha1.Cluster{notReadyCluster("shoot-a", "kubeconfig invalid")},
+			nil,
+		)
+
+		Expect(statuses).To(HaveLen(1))
+		Expect(statuses[0].Status).To(Equal(v1alpha1.ShootStatusExcluded))
+		Expect(failed).To(Equal(0))
+	})
+
+	It("reports owned clusters as onboarded or failed", func() {
+		statuses, failed := buildShootStatuses(
+			nil,
+			[]greenhousev1alpha1.Cluster{
+				readyCluster("shoot-ready"),
+				notReadyCluster("shoot-broken", "kubeconfig invalid"),
+			},
+			nil,
+		)
+
+		Expect(statuses).To(HaveLen(2))
+		Expect(statuses[0].Name).To(Equal("shoot-broken"))
+		Expect(statuses[0].Status).To(Equal(v1alpha1.ShootStatusFailed))
+		Expect(statuses[0].Message).To(Equal("kubeconfig invalid"))
+		Expect(statuses[1].Name).To(Equal("shoot-ready"))
+		Expect(statuses[1].Status).To(Equal(v1alpha1.ShootStatusOnboarded))
+		Expect(failed).To(Equal(1))
+	})
+
+	It("reports ownership conflicts with the owning CareInstruction", func() {
+		statuses, failed := buildShootStatuses(
+			nil,
+			nil,
+			map[string]conflictInfo{
+				"shoot-taken":  {owner: "other-ci", ready: true},
+				"shoot-broken": {owner: "other-ci", ready: false},
+			},
+		)
+
+		Expect(statuses).To(HaveLen(2))
+		Expect(statuses[0].Name).To(Equal("shoot-broken"))
+		Expect(statuses[0].Status).To(Equal(v1alpha1.ShootStatusFailed))
+		Expect(statuses[0].Message).To(Equal("Cluster managed by different CareInstruction: other-ci"))
+		Expect(statuses[1].Name).To(Equal("shoot-taken"))
+		Expect(statuses[1].Status).To(Equal(v1alpha1.ShootStatusOnboarded))
+		Expect(failed).To(Equal(1))
+	})
+
+	It("returns entries sorted by name regardless of input order", func() {
+		statuses, _ := buildShootStatuses(
+			map[string]string{"zulu": "excluded for test reasons", "alpha": "excluded for test reasons"},
+			[]greenhousev1alpha1.Cluster{readyCluster("mike"), readyCluster("bravo")},
+			nil,
+		)
+
+		names := make([]string, 0, len(statuses))
+		for _, status := range statuses {
+			names = append(names, status.Name)
+		}
+		Expect(names).To(Equal([]string{"alpha", "bravo", "mike", "zulu"}))
+	})
+
+	It("returns an empty slice when there is nothing to report", func() {
+		statuses, failed := buildShootStatuses(nil, nil, nil)
+
+		Expect(statuses).To(BeEmpty())
+		Expect(failed).To(Equal(0))
+	})
+})
+
+var _ = Describe("shootStatusRank", func() {
+	It("ranks Excluded above Failed above Onboarded", func() {
+		Expect(shootStatusRank(v1alpha1.ShootStatusExcluded)).To(BeNumerically(">", shootStatusRank(v1alpha1.ShootStatusFailed)))
+		Expect(shootStatusRank(v1alpha1.ShootStatusFailed)).To(BeNumerically(">", shootStatusRank(v1alpha1.ShootStatusOnboarded)))
+	})
+})


### PR DESCRIPTION
## Summary

A shoot that was onboarded and later stopped matching the CEL expression was listed twice in `.status.shoots`, once as `Excluded` and once as `Onboarded`. The shoot loop and the owned-cluster loop appended independently, so nothing deduplicated them by name.

- new `shootstatus.go` merges all status sources into one entry per shoot name, precedence `Excluded > Failed > Onboarded`, sorted by name
- `FailedClusters` is derived from the merged result instead of incremented while building
- the count check compares included shoots against owned clusters that still match, so an excluded shoot no longer blocks `ShootsReconciled`

Closes #64